### PR TITLE
Add Clipper Tests

### DIFF
--- a/TVGLTest/TVGLTest.csproj
+++ b/TVGLTest/TVGLTest.csproj
@@ -37,6 +37,10 @@
     <Reference Include="Microsoft.Office.Interop.Excel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="OxyPlot, Version=1.0.0.0, Culture=neutral, PublicKeyToken=638079a8f0bd61e9, processorArchitecture=MSIL">
       <HintPath>..\packages\OxyPlot.Core.1.0.0-unstable2100\lib\net45\OxyPlot.dll</HintPath>
       <Private>True</Private>

--- a/TVGLTest/TVGLTest.csproj
+++ b/TVGLTest/TVGLTest.csproj
@@ -72,6 +72,7 @@
     <Compile Include="ExcelInterface.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Test\BooleanOperationsTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/TVGLTest/Test/BooleanOperationsTest.cs
+++ b/TVGLTest/Test/BooleanOperationsTest.cs
@@ -1,0 +1,1496 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using TVGL.Boolean_Operations.Clipper;
+
+namespace TVGLTest.Test
+{
+    using Path = List<IntPoint>;
+    using Paths = List<List<IntPoint>>;
+
+    [TestFixture]
+    class ClipperTest
+    {
+        Paths subject;
+        Paths subject2;
+        Paths clip;
+        Paths solution;
+        PolyTree polytree;
+        Clipper clipper;
+
+        [SetUp]
+        public void TestSetup()
+        {
+            subject = new Paths();
+            subject2 = new Paths();
+            clip = new Paths();
+            solution = new Paths();
+            polytree = new PolyTree();
+            clipper = new Clipper();
+        }
+
+        private Path MakePolygonFromInts(int[] ints, double scale = 1.0)
+        {
+            var polygon = new Path();
+
+            for (var i = 0; i < ints.Length; i += 2)
+            {
+                polygon.Add(new IntPoint(scale * ints[i], scale * ints[i + 1]));
+            }
+
+            return polygon;
+        }
+
+        private void MakeSquarePolygons(int size, int totalWidth, int totalHeight, Paths result)
+        {
+            int cols = totalWidth / size;
+            int rows = totalHeight / size;
+            Path[] paths = new Path[cols * rows];
+            for (int i = 0; i < rows; ++i)
+            {
+                for (int j = 0; j < cols; ++j)
+                {
+                    int[] ints = {
+                        j * size,
+                        i * size,
+                        (j+1) * size,
+                        i * size,
+                        (j+1) * size,
+                        (i+1) * size,
+                        j * size,
+                        (i+1) * size
+                    };
+
+                    paths[j * rows + i] = MakePolygonFromInts(ints);
+                }
+            }
+
+            result.Clear();
+            result.AddRange(paths);
+        }
+
+        private void MakeDiamondPolygons(int size, int totalWidth, int totalHeight, Paths result)
+        {
+            int halfSize = size / 2;
+            size = halfSize * 2;
+            int cols = totalWidth / size;
+            int rows = totalHeight * 2 / size;
+            Path[] paths = new Path[cols * rows];
+            int dx = 0;
+            for (int i = 0; i < rows; ++i)
+            {
+                if (dx == 0) dx = halfSize; else dx = 0;
+                for (int j = 0; j < cols; ++j)
+                {
+                    int[] ints = {
+                        dx + j * size,
+                        i * halfSize + halfSize,
+                        dx + j * size + halfSize,
+                        i * halfSize,
+                        dx + (j+1) * size,
+                        i * halfSize + halfSize,
+                        dx + j * size + halfSize,
+                        i * halfSize + halfSize *2
+                    };
+
+                    paths[j * rows + i] = MakePolygonFromInts(ints);
+                }
+            }
+
+            result.Clear();
+            result.AddRange(paths);
+        }
+
+        [Test]
+        public void Difference1()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints1 = { 29, 342, 115, 68, 141, 86 };
+            int[] ints2 = { 128, 160, 99, 132, 97, 174 };
+            int[] ints3 = { 99, 212, 128, 160, 97, 174, 58, 160 };
+            int[] ints4 = { 97, 174, 99, 132, 60, 124, 58, 160 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void Difference2()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints1 = { -103, -219, -103, -136, -115, -136 };
+            int[] ints2 = { -110, -174, -70, -174, -110, -155 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Horz1()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints1 = { 380, 280, 450, 280, 130, 400, 490, 430, 320, 200, 450, 260 };
+            int[] ints2 = { 350, 240, 520, 470, 100, 300 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.LessThanOrEqualTo(2));
+        }
+
+        [Test]
+        public void Horz2()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints1 = { 120, 400, 350, 380, 340, 140 };
+            int[] ints2 = { 350, 370, 150, 370, 560, 20, 350, 390, 340, 150, 570, 230, 390, 40 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Horz3()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints1 = { 470, 190, 100, 520, 280, 270, 380, 270, 460, 170 };
+            int[] ints2 = { 170, 70, 500, 350, 110, 90 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Horz4()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+            int[] ints1 = { 904, 901, 1801, 901, 1801, 1801, 902, 1803 };
+            int[] ints2 = { 2, 1800, 902, 1800, 902, 2704, 4, 2701 };
+            int[] ints3 = { 902, 1802, 902, 2704, 1804, 2703, 1801, 1804 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+            subject.Add(MakePolygonFromInts(ints3));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.False);
+        }
+
+        [Test]
+        public void Horz5()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 93, 92, 183, 93, 184, 184, 94, 183 };
+            int[] ints2 = { 184, 1, 270, 2, 272, 91, 183, 94 };
+            int[] ints3 = { 92, 2, 91, 91, 184, 91, 184, 0 };
+            int[] ints4 = { 183, 93, 184, 184, 271, 182, 274, 94 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Horz6()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 14, 15, 16, 12, 10, 12 };
+            int[] ints2 = { 15, 14, 11, 14, 13, 16, 17, 10, 10, 17, 18, 13 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Horz7()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 11, 19, 19, 15, 15, 12, 13, 19, 15, 13, 10, 14, 13, 18, 16, 13 };
+            int[] ints2 = { 16, 10, 14, 17, 18, 10, 15, 18, 14, 14, 15, 14, 11, 16 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Horz8()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 12, 11, 15, 15, 18, 16, 16, 18, 15, 14, 14, 14, 19, 15 };
+            int[] ints2 = { 13, 12, 17, 17, 19, 15 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void Horz9()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints1 = { 380, 140, 430, 120, 180, 120, 430, 120, 190, 150 };
+            int[] ints2 = { 430, 130, 210, 70, 20, 260 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void Horz10()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints1 = { 40, 310, 410, 110, 460, 110, 260, 200 };
+            int[] ints2 = { 120, 260, 450, 220, 330, 220, 240, 220, 50, 380 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void Orientation1()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints1 = {470, 130, 330, 10, 370, 10,
+                290, 190, 290, 280, 190, 10, 70, 370, 10, 400, 310, 10, 490, 220,
+                130, 10, 150, 400, 490, 150, 250, 60, 410, 320, 430, 410,
+                470, 10, 10, 10, 250, 220, 10, 180, 250, 160, 490, 130, 190, 320,
+                170, 240, 290, 280, 370, 240, 350, 90, 450, 190, 10, 370,
+                110, 180, 290, 160, 190, 350, 490, 360, 190, 190, 370, 230,
+                90, 220, 270, 10, 70, 190, 10, 270, 430, 100, 190, 140, 370, 80,
+                10, 40, 250, 260, 430, 40, 130, 350, 190, 420, 10, 10, 130, 50,
+                90, 400, 530, 50, 150, 90, 250, 150, 390, 310, 250, 180,
+                310, 220, 350, 280, 30, 140, 430, 260, 130, 10, 430, 310,
+                10, 60, 190, 60, 490, 320, 190, 360, 430, 130, 210, 220,
+                270, 190, 10, 10, 510, 10, 150, 210, 90, 400, 110, 10, 130, 110,
+                130, 80, 130, 30, 430, 190, 190, 380, 90, 300, 10, 340, 10, 70,
+                250, 380, 310, 370, 370, 240, 190, 130, 490, 100, 470, 70,
+                10, 420, 190, 20, 430, 290, 430, 10, 330, 70, 450, 140, 430, 40,
+                150, 220, 170, 190, 10, 110, 470, 310, 510, 160, 10, 200
+            };
+            int[] ints2 = {50, 420, 10, 180, 190, 160,
+                50, 40, 490, 40, 450, 130, 450, 290, 290, 310, 430, 110,
+                370, 250, 490, 220, 430, 230, 410, 220, 10, 200, 530, 130,
+                50, 350, 370, 290, 130, 130, 110, 390, 10, 350, 210, 340,
+                370, 220, 530, 280, 370, 170, 190, 370, 330, 310, 510, 280,
+                90, 10, 50, 250, 170, 100, 110, 40, 310, 370, 430, 80, 390, 40,
+                250, 360, 350, 150, 130, 310, 10, 260, 390, 90, 370, 280,
+                70, 100, 530, 190, 10, 250, 470, 340, 110, 180, 10, 10, 70, 380,
+                370, 60, 190, 290, 250, 70, 10, 150, 70, 120, 490, 340, 330, 40,
+                90, 10, 210, 40, 50, 10, 450, 370, 310, 390, 10, 10, 10, 270,
+                250, 180, 130, 120, 10, 150, 10, 220, 150, 280, 490, 10,
+                150, 370, 370, 220, 10, 310, 10, 330, 450, 150, 310, 80,
+                410, 40, 530, 290, 110, 240, 70, 140, 190, 410, 10, 250,
+                270, 230, 370, 380, 270, 280, 230, 220, 430, 110, 10, 290,
+                130, 250, 190, 40, 170, 320, 210, 220, 290, 40, 370, 380,
+                30, 380, 130, 50, 370, 340, 130, 190, 70, 250, 310, 270,
+                250, 290, 310, 280, 230, 150
+            };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            for (var i = 0; i < solution.Count; ++i)
+            {
+                Assert.That(Clipper.Orientation(solution[i]), Is.True);
+            }
+        }
+
+        [Test]
+        public void Orientation2()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = {370, 150, 130, 400, 490, 290,
+                490, 400, 170, 10, 130, 130, 270, 90, 430, 230, 310, 230,
+                10, 80, 390, 110, 370, 20, 190, 210, 370, 410, 110, 100,
+                410, 230, 370, 290, 350, 190, 350, 100, 230, 290
+            };
+            int[] ints2 = {510, 400, 250, 100, 410, 410,
+                170, 210, 390, 100, 10, 100, 10, 250, 10, 220, 130, 90, 410, 330,
+                450, 160, 50, 180, 110, 100, 210, 320, 410, 220, 190, 30,
+                370, 70, 270, 260, 450, 250, 90, 280
+            };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            int count = 0;
+            for (var i = 0; i < solution.Count; ++i)
+            {
+                if (!Clipper.Orientation(solution[i])) count++;
+            }
+            Assert.That(count, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void Orientation3()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints1 = { 70, 290, 10, 410, 10, 220 };
+            int[] ints2 = { 430, 20, 10, 30, 10, 370, 250, 300, 190, 10, 10, 370, 30, 220, 490, 100, 10, 370 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            for (var i = 0; i < solution.Count; ++i)
+            {
+                Assert.That(Clipper.Orientation(solution[i]), Is.True);
+            }
+        }
+
+        [Test]
+        public void Orientation4()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = {40, 190, 400, 10, 510, 450,
+                300, 50, 440, 230, 340, 290, 260, 510, 110, 50, 500, 90,
+                450, 410, 550, 70, 70, 130, 410, 110, 130, 130, 470, 50,
+                410, 10, 360, 50, 460, 90, 170, 270, 400, 210, 240, 370,
+                50, 370, 350, 270, 530, 330, 170, 250, 440, 170, 40, 430,
+                410, 90, 170, 510, 470, 130, 290, 390, 510, 410, 500, 230,
+                490, 490, 430, 430, 10, 250, 240, 190, 80, 370, 60, 190,
+                570, 490, 110, 270, 550, 290, 90, 10, 200, 10, 580, 450,
+                500, 450, 370, 210, 10, 250, 60, 70, 220, 10, 530, 130, 190, 10,
+                350, 170, 440, 330, 260, 50, 320, 10, 570, 10, 350, 170,
+                130, 470, 350, 370, 40, 130, 540, 50, 10, 50, 320, 450, 270, 470,
+                460, 10, 60, 110, 280, 170, 300, 410, 300, 370, 520, 170,
+                460, 410, 180, 270, 270, 450, 50, 110, 490, 490, 10, 150,
+                240, 490, 200, 190, 10, 10, 30, 370, 170, 410, 560, 290,
+                140, 10, 350, 190, 290, 10, 460, 210, 70, 290, 300, 270,
+                570, 450, 250, 330, 250, 290, 300, 410, 210, 330, 320, 390,
+                160, 290, 70, 190, 40, 170, 490, 70, 70, 50
+            };
+            int[] ints2 = {160, 510, 440, 90, 400, 510,
+                220, 250, 480, 210, 80, 410, 530, 170, 10, 50, 220, 290,
+                110, 490, 110, 10, 350, 130, 510, 330, 10, 410, 190, 30,
+                90, 10, 380, 270, 50, 250, 510, 50, 580, 10, 50, 130, 540, 330,
+                120, 250, 440, 250, 10, 430, 10, 410, 150, 190, 510, 490,
+                400, 170, 200, 10, 170, 470, 300, 10, 130, 130, 190, 10,
+                500, 350, 40, 10, 400, 230, 20, 370, 230, 510, 140, 10, 220, 490,
+                90, 370, 490, 190, 520, 210, 180, 70, 440, 490, 510, 10,
+                420, 210, 340, 410, 80, 10, 100, 190, 100, 250, 340, 390,
+                360, 10, 170, 70, 300, 290, 110, 370, 160, 330, 210, 10,
+                300, 10, 540, 410, 380, 490, 550, 290, 170, 450, 580, 390,
+                360, 10, 450, 370, 520, 330, 100, 30, 160, 450, 160, 190,
+                300, 90, 400, 270, 40, 170, 40, 90, 210, 330, 450, 50, 430, 370,
+                290, 370, 150, 10, 340, 170, 10, 90, 180, 150, 530, 450,
+                310, 490, 400, 450, 340, 10, 420, 210, 500, 70, 100, 10,
+                400, 470, 40, 490, 550, 190, 30, 90, 100, 130, 70, 490, 20, 270,
+                490, 410, 570, 370, 220, 90
+            };
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            int count = 0;
+            for (var i = 0; i < solution.Count; ++i)
+            {
+                if (!Clipper.Orientation(solution[i])) count++;
+            }
+            Assert.That(count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Orientation5()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = {5237, 5237, 68632, 5164, 10315, 61247,
+    10315, 20643, 16045, 29877, 24374, 11012, 10359, 19690, 10315, 20643,
+    10315, 67660};
+
+            subject.Add(MakePolygonFromInts(ints1));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[1]), Is.False);
+        }
+
+        [Test]
+        public void Orientation6()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 100, 0, 101, 116, 0, 109 };
+            int[] ints2 = { 110, 112, 200, 106, 200, 200, 111, 200 };
+            int[] ints3 = { 0, 106, 101, 114, 107, 200, 0, 200 };
+            int[] ints4 = { 117, 0, 200, 0, 200, 110, 115, 102 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void Orientation7()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 100, 0, 104, 116, 0, 118 };
+            int[] ints2 = { 111, 115, 200, 103, 200, 200, 105, 200 };
+            int[] ints3 = { 0, 103, 112, 111, 105, 200, 0, 200 };
+            int[] ints4 = { 116, 0, 200, 0, 200, 113, 101, 110 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void Orientation8()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 112, 0, 111, 116, 0, 108 };
+            int[] ints2 = { 112, 114, 200, 108, 200, 200, 116, 200 };
+            int[] ints3 = { 0, 102, 118, 111, 117, 200, 0, 200 };
+            int[] ints4 = { 109, 0, 200, 0, 200, 117, 105, 110 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void Orientation9()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 114, 0, 113, 110, 0, 117 };
+            int[] ints2 = { 109, 114, 200, 106, 200, 200, 104, 200 };
+            int[] ints3 = { 0, 100, 118, 106, 103, 200, 0, 200 };
+            int[] ints4 = { 110, 0, 200, 0, 200, 116, 101, 105 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void Orientation10()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 102, 0, 103, 118, 0, 106 };
+            int[] ints2 = { 110, 115, 200, 108, 200, 200, 113, 200 };
+            int[] ints3 = { 0, 110, 103, 117, 109, 200, 0, 200 };
+            int[] ints4 = { 118, 0, 200, 0, 200, 108, 116, 101 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void Orientation11()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 100, 0, 107, 116, 0, 104 };
+            int[] ints2 = { 116, 100, 200, 115, 200, 200, 118, 200 };
+            int[] ints3 = { 0, 115, 107, 115, 115, 200, 0, 200 };
+            int[] ints4 = { 101, 0, 200, 0, 200, 100, 100, 100 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void Orientation12()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 119, 0, 113, 105, 0, 100 };
+            int[] ints2 = { 117, 103, 200, 105, 200, 200, 106, 200 };
+            int[] ints3 = { 0, 112, 116, 104, 108, 200, 0, 200 };
+            int[] ints4 = { 101, 0, 200, 0, 200, 117, 104, 112 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void Orientation13()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 119, 0, 109, 108, 0, 101 };
+            int[] ints2 = { 115, 100, 200, 103, 200, 200, 101, 200 };
+            int[] ints3 = { 0, 117, 110, 100, 103, 200, 0, 200 };
+            int[] ints4 = { 115, 0, 200, 0, 200, 109, 119, 102 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void Orientation14()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 102, 0, 119, 107, 0, 101 };
+            int[] ints2 = { 116, 110, 200, 114, 200, 200, 107, 200 };
+            int[] ints3 = { 0, 108, 117, 106, 111, 200, 0, 200 };
+            int[] ints4 = { 112, 0, 200, 0, 200, 117, 101, 112 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void Orientation15()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 106, 0, 107, 111, 0, 102 };
+            int[] ints2 = { 119, 116, 200, 118, 200, 200, 117, 200 };
+            int[] ints3 = { 0, 101, 107, 106, 111, 200, 0, 200 };
+            int[] ints4 = { 113, 0, 200, 0, 200, 114, 117, 117 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void SelfInt1()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 201, 0, 203, 217, 0, 207 };
+            int[] ints2 = { 204, 214, 400, 217, 400, 400, 205, 400 };
+            int[] ints3 = { 0, 211, 203, 214, 208, 400, 0, 400 };
+            int[] ints4 = { 207, 0, 400, 0, 400, 208, 218, 200 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void SelfInt2()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 200, 0, 219, 207, 0, 200 };
+            int[] ints2 = { 201, 207, 400, 200, 400, 400, 200, 400 };
+            int[] ints3 = { 0, 200, 214, 207, 200, 400, 0, 400 };
+            int[] ints4 = { 200, 0, 400, 0, 400, 200, 209, 215 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void SelfInt3()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 201, 0, 207, 214, 0, 207 };
+            int[] ints2 = { 209, 211, 400, 206, 400, 400, 214, 400 };
+            int[] ints3 = { 0, 211, 207, 208, 213, 400, 0, 400 };
+            int[] ints4 = { 213, 0, 400, 0, 400, 210, 213, 200 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void SelfInt4()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 0, 0, 214, 0, 209, 206, 0, 201 };
+            int[] ints2 = { 205, 208, 400, 207, 400, 400, 200, 400 };
+            int[] ints3 = { 201, 0, 400, 0, 400, 217, 205, 217 };
+            int[] ints4 = { 0, 205, 215, 206, 217, 400, 0, 400 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+        }
+
+        [Test]
+        public void SelfInt5()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints1 = { 0, 0, 219, 0, 217, 217, 0, 200 };
+            int[] ints2 = { 214, 219, 400, 200, 400, 400, 219, 400 };
+            int[] ints3 = { 0, 207, 205, 211, 214, 400, 0, 400 };
+            int[] ints4 = { 202, 0, 400, 0, 400, 217, 205, 217 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clip.Add(MakePolygonFromInts(ints3));
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Difference, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.True);
+
+        }
+
+        [Test]
+        public void SelfInt6()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints = { 182, 179, 477, 123, 25, 55 };
+            int[] ints2 = { 477, 122, 485, 103, 122, 265, 55, 207 };
+
+            subject.Add(MakePolygonFromInts(ints));
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+        }
+
+        [Test]
+        public void Union1()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+
+            int[] ints1 = { 1026, 1126, 1026, 235, 4505, 401, 4522, 1145, 4503, 1162, 2280, 1129 };
+            int[] ints2 = { 4501, 1100, 4501, 866, 1146, 462, 1071, 1067, 4469, 1000 };
+            int[] ints3 = { 4499, 1135, 3360, 1050, 3302, 1107 };
+            int[] ints4 = { 3360, 1050, 3291, 1118, 4512, 1136 };
+
+            subject.Add(MakePolygonFromInts(ints1));
+            subject.Add(MakePolygonFromInts(ints2));
+            subject.Add(MakePolygonFromInts(ints3));
+
+            clip.Add(MakePolygonFromInts(ints4));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.True);
+            Assert.That(Clipper.Orientation(solution[1]), Is.False);
+        }
+
+        [Test]
+        public void Union2()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[][] ints = {
+                new int[] {10, 10, 20, 10, 20, 20, 10, 20},
+                new int[] {20, 10, 30, 10, 30, 20, 20, 20},
+                new int[] {30, 10, 40, 10, 40, 20, 30, 20},
+                new int[] {40, 10, 50, 10, 50, 20, 40, 20},
+                new int[] {50, 10, 60, 10, 60, 20, 50, 20},
+                new int[] {10, 20, 20, 20, 20, 30, 10, 30},
+                new int[] {30, 20, 40, 20, 40, 30, 30, 30},
+                new int[] {10, 30, 20, 30, 20, 40, 10, 40},
+                new int[] {20, 30, 30, 30, 30, 40, 20, 40},
+                new int[] {30, 30, 40, 30, 40, 40, 30, 40},
+                new int[] {40, 30, 50, 30, 50, 40, 40, 40}
+            };
+
+            for (var i = 0; i < 11; ++i)
+            {
+                subject.Add(MakePolygonFromInts(ints[i]));
+            }
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Union3()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+            int[][] ints = {
+                new int[] { 1, 3, 2, 4, 2, 5 },
+                new int[] { 1, 3, 3, 3, 2, 4 }
+            };
+
+            for (var i = 0; i < 2; ++i)
+            {
+                subject.Add(MakePolygonFromInts(ints[i]));
+            }
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void AddPath1()
+        {
+
+            int[] ints = { 480, 20, 480, 110, 320, 30, 480, 30, 250, 250, 480, 30 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath2()
+        {
+
+            int[] ints = { 60, 320, 390, 320, 100, 320, 220, 120, 120, 10, 20, 380, 120, 20, 280, 20, 480, 20 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath3()
+        {
+            int[] ints = { 320, 70, 420, 370, 250, 170, 60, 290, 10, 290, 210, 290, 400, 150, 410, 340 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath4()
+        {
+
+            int[] ints = { 300, 80, 280, 220, 180, 220, 170, 220, 290, 220, 40, 180 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath5()
+        {
+
+            int[] ints = { 170, 340, 280, 230, 160, 50, 430, 370, 280, 230 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath6()
+        {
+
+            int[] ints = { 30, 380, 70, 160, 170, 220, 70, 160, 240, 160 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath7()
+        {
+
+            int[] ints = { 440, 300, 40, 40, 440, 300, 80, 360 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath8()
+        {
+
+            int[] ints = { 260, 10, 260, 240, 190, 100, 260, 10, 420, 120 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath9()
+        {
+
+            int[] ints = { 60, 240, 30, 10, 460, 170, 110, 280, 30, 10 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath10()
+        {
+
+            int[] ints = { 430, 270, 440, 260, 470, 30, 280, 30, 430, 270, 450, 40 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath11()
+        {
+
+            int[] ints = { 320, 10, 240, 300, 260, 140, 320, 10, 240, 300 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath12()
+        {
+
+            int[] ints = { 270, 340, 130, 50, 50, 350, 270, 340, 290, 40 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath13()
+        {
+
+            int[] ints = { 430, 330, 280, 10, 210, 280, 430, 330, 280, 10 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath14()
+        {
+            int[] ints = { 50, 30, 410, 330, 50, 30, 310, 50 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath15()
+        {
+
+            int[] ints = { 230, 50, 10, 50, 110, 50 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath16()
+        {
+
+            int[] ints = { 260, 320, 40, 130, 100, 30, 80, 360, 260, 320, 40, 50 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath17()
+        {
+
+            int[] ints = { 190, 170, 350, 290, 110, 290, 250, 290, 430, 90 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath18()
+        {
+
+            int[] ints = { 150, 330, 210, 70, 90, 70, 210, 70, 150, 330 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath19()
+        {
+
+            int[] ints = { 170, 290, 50, 290, 170, 290, 410, 310, 170, 290 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void AddPath20()
+        {
+
+            int[] ints = { 430, 10, 150, 110, 430, 10, 230, 50 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+        }
+
+        [Test]
+        public void OpenPath1()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints = { 290, 370, 160, 150, 230, 150, 160, 150, 250, 280 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+            int[] ints2 = { 150, 10, 160, 290, 200, 80, 50, 340 };
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, polytree, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void OpenPath2()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints = { 50, 310, 210, 110, 260, 110, 170, 110, 350, 200 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+            int[] ints2 = { 310, 30, 90, 90, 370, 130 };
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, polytree, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void OpenPath3()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints = { 40, 360, 260, 50, 180, 270, 180, 250, 410, 250, 140, 250, 350, 380 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+            int[] ints2 = { 30, 110, 330, 90, 20, 370 };
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, polytree, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void OpenPath4()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+
+            int[] ints = { 10, 50, 200, 50 };
+
+            subject2.Add(MakePolygonFromInts(ints));
+            int[] ints2 = { 50, 10, 150, 10, 150, 100, 50, 100 };
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject2, PolyType.Subject, false);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Intersection, polytree, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(polytree.ChildCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Simplify1()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+            int[] ints = { 5048400, 1719180, 5050250, 1717630, 5049070, 1717320, 5049150, 1717200, 5049350, 1717570 };
+
+            subject.Add(MakePolygonFromInts(ints));
+
+            clipper.StrictlySimple = true;
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Simplify2()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+            int[] ints = { 220, 720, 420, 720, 420, 520, 320, 520, 320, 480, 480, 480, 480, 800, 180, 800, 180, 480, 320, 480, 320, 520, 220, 520 };
+            int[] ints2 = { 440, 520, 620, 520, 620, 420, 440, 420 };
+
+            subject.Add(MakePolygonFromInts(ints));
+            subject.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Joins1()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+            int[][] ints = {
+                new int[] {0, 0, 0, 32, 32, 32, 32, 0},
+                new int[] {32, 0, 32, 32, 64, 32, 64, 0},
+                new int[] {64, 0, 64, 32, 96, 32, 96, 0},
+                new int[] {96, 0, 96, 32, 128, 32, 128, 0},
+                new int[] {0, 32, 0, 64, 32, 64, 32, 32},
+                new int[] {64, 32, 64, 64, 96, 64, 96, 32},
+                new int[] {0, 64, 0, 96, 32, 96, 32, 64},
+                new int[] {32, 64, 32, 96, 64, 96, 64, 64}
+            };
+
+            for (var i = 0; i < 8; ++i)
+            {
+                subject.Add(MakePolygonFromInts(ints[i]));
+            }
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Joins2()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+            int[][] ints = {
+                new int[] {100, 100, 100, 91, 200, 91, 200, 100},
+                new int[] {200, 91, 209, 91, 209, 250, 200, 250},
+                new int[] {209, 250, 209, 259, 100, 259, 100, 250},
+                new int[] {100, 250, 109, 250, 109, 300, 100, 300},
+                new int[] {109, 300, 109, 309, 50, 309, 50, 300},
+                new int[] {50, 309, 41, 309, 41, 250, 50, 250},
+                new int[] {50, 250, 50, 259, 0, 259, 0, 250},
+                new int[] {0, 259, -9, 259, -9, 100, 0, 100},
+                new int[] {-9, 100, -9, 91, 50, 91, 50, 100},
+                new int[] {50, 100, 41, 100, 41, 50, 50, 50},
+                new int[] {41, 50, 41, 41, 100, 41, 100, 50},
+                new int[] {100, 41, 109, 41, 109, 100, 100, 100}
+            };
+
+            for (var i = 0; i < 12; ++i)
+            {
+                subject.Add(MakePolygonFromInts(ints[i]));
+            }
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.Not.EqualTo(Clipper.Orientation(solution[1])));
+        }
+
+        [Test]
+        public void Joins3()
+        {
+            PolyFillType fillMethod = PolyFillType.NonZero;
+            int[] ints = { 220, 720, 420, 720, 420, 520, 320, 520, 320, 480, 480, 480, 480, 800, 180, 800, 180, 480, 320, 480, 320, 520, 220, 520 };
+
+            subject.Add(MakePolygonFromInts(ints));
+            int[] ints2 = { 440, 520, 620, 520, 620, 420, 440, 420 };
+
+            clip.Add(MakePolygonFromInts(ints2));
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            clipper.AddPaths(clip, PolyType.Clip, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(2));
+            Assert.That(Clipper.Orientation(solution[0]), Is.Not.EqualTo(Clipper.Orientation(solution[1])));
+        }
+
+        [Test]
+        public void Joins4()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+            int[] ints = {
+                1172, 318, 337, 1066, 154, 639, 479, 448, 1197, 545, 1041, 773, 30, 888,
+                444, 308, 1051, 552, 1109, 102, 658, 683, 394, 596, 972, 1145, 442, 179,
+                470, 441, 227, 564, 1179, 1037, 213, 379, 1072, 872, 587, 171, 723, 329,
+                272, 242, 952, 1121, 714, 1148, 91, 217, 735, 561, 903, 1009, 664, 1168,
+                1160, 847, 9, 7, 619, 142, 1139, 1116, 1134, 369, 760, 647, 372, 134,
+                1106, 183, 311, 103, 265, 185, 1062, 856, 453, 944, 44, 653, 766, 527,
+                334, 965, 443, 971, 474, 36, 397, 1138, 901, 841, 775, 612, 222, 465,
+                148, 955, 417, 540, 997, 472, 666, 802, 754, 32, 907, 638, 927, 42, 990,
+                406, 99, 682, 17, 281, 106, 848
+            };
+            MakeDiamondPolygons(20, 600, 400, subject);
+            for (int i = 0; i < 120; ++i) subject[ints[i]].Clear();
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(69));
+        }
+
+        [Test]
+        public void Joins5()
+        {
+            PolyFillType fillMethod = PolyFillType.EvenOdd;
+            int[] ints = {
+                553, 388, 574, 20, 191, 26, 461, 258, 509, 19, 466, 257, 90, 269, 373, 516,
+                350, 333, 288, 141, 47, 217, 247, 519, 535, 336, 504, 497, 344, 341, 293,
+                177, 558, 598, 399, 286, 482, 185, 266, 24, 27, 118, 338, 413, 514, 510,
+                366, 46, 593, 465, 405, 32, 449, 6, 326, 59, 75, 173, 127, 130
+            };
+            MakeSquarePolygons(20, 600, 400, subject);
+            for (int i = 0; i < 60; ++i) subject[ints[i]].Clear();
+
+            clipper.AddPaths(subject, PolyType.Subject, true);
+            bool result = clipper.Execute(ClipType.Union, solution, fillMethod, fillMethod);
+
+            Assert.That(result, Is.True);
+            Assert.That(solution.Count, Is.EqualTo(37));
+        }
+
+        [Test]
+        public void OffsetPoly1()
+        {
+            const double scale = 10;
+            int[] ints2 = { 348, 257, 364, 148, 362, 148, 326, 241, 295, 219, 258, 88, 440, 129, 370, 196, 372, 275 };
+
+            subject.Add(MakePolygonFromInts(ints2, scale));
+            ClipperOffset clipperOffset = new ClipperOffset();
+            clipperOffset.AddPaths(subject, JoinType.Round, EndType.ClosedPolygon);
+            clipperOffset.Execute(ref solution, -7.0 * scale);
+
+            Assert.That(solution.Count, Is.EqualTo(2));
+        }
+    }
+}

--- a/TVGLTest/packages.config
+++ b/TVGLTest/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="NUnit" version="3.4.1" targetFramework="net45" />
   <package id="OxyPlot.Core" version="1.0.0-unstable2100" targetFramework="net45" />
   <package id="OxyPlot.Wpf" version="1.0.0-unstable2100" targetFramework="net45" />
   <package id="PropertyTools.Wpf" version="2015.2.0" targetFramework="net45" />

--- a/TessellationAndVoxelizationGeometryLibrary.NET4.5/Properties/AssemblyInfo.cs
+++ b/TessellationAndVoxelizationGeometryLibrary.NET4.5/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -25,3 +26,6 @@
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+// Allow tests to access internal classes
+[assembly: InternalsVisibleTo("TVGLTest")]

--- a/TessellationAndVoxelizationGeometryLibrary/Boolean Operations/PolygonOperations.cs
+++ b/TessellationAndVoxelizationGeometryLibrary/Boolean Operations/PolygonOperations.cs
@@ -81,32 +81,32 @@ namespace TVGL.Boolean_Operations
         /// <returns></returns>
         public static List<Point> Round(IList<Point> loop, double offset, double scale = 100000)
         {
-            var loops = new List<List<Point>> {new List<Point>(loop)};
+            var loops = new List<List<Point>> { new List<Point>(loop) };
             var offsetLoops = Round(loops, offset, scale);
             return offsetLoops.First();
         }
 
 
         /// <summary>
-            /// Offsets all loops by the given offset value. Rounds the corners.
-            /// Offest value may be positive or negative.
-            /// Loops must be ordered CCW positive.
-            /// </summary>
-            /// <param name="loops"></param>
-            /// <param name="offset"></param>
-            /// <param name="scale"></param>
-            /// <returns></returns>
+        /// Offsets all loops by the given offset value. Rounds the corners.
+        /// Offest value may be positive or negative.
+        /// Loops must be ordered CCW positive.
+        /// </summary>
+        /// <param name="loops"></param>
+        /// <param name="offset"></param>
+        /// <param name="scale"></param>
+        /// <returns></returns>
         public static List<List<Point>> Round(List<List<Point>> loops, double offset, double scale = 100000)
         {
             //Convert Points (TVGL) to IntPoints (Clipper)
             var polygons =
-                loops.Select(loop => loop.Select(point => new IntPoint(point.X*scale, point.Y*scale)).ToList()).ToList();
+                loops.Select(loop => loop.Select(point => new IntPoint(point.X * scale, point.Y * scale)).ToList()).ToList();
 
             //Begin an evaluation
             var solution = new List<List<IntPoint>>();
             var clip = new ClipperOffset();
             clip.AddPaths(polygons, JoinType.jtRound, EndType.etClosedPolygon);
-            clip.Execute(ref solution, offset*scale);
+            clip.Execute(ref solution, offset * scale);
 
             var offsetLoops = new List<List<Point>>();
             foreach (var loop in solution)
@@ -115,9 +115,9 @@ namespace TVGL.Boolean_Operations
                 for (var i = 0; i < loop.Count; i++)
                 {
                     var intPoint = loop[i];
-                    var x = Convert.ToDouble(intPoint.X)/scale;
-                    var y = Convert.ToDouble(intPoint.Y)/scale;
-                    offsetLoop.Add(new Point(new List<double> {x, y, 0.0}));
+                    var x = Convert.ToDouble(intPoint.X) / scale;
+                    var y = Convert.ToDouble(intPoint.Y) / scale;
+                    offsetLoop.Add(new Point(new List<double> { x, y, 0.0 }));
                 }
                 offsetLoops.Add(offsetLoop);
             }
@@ -130,11 +130,11 @@ namespace TVGL.Boolean_Operations
 
 namespace TVGL.Boolean_Operations.Clipper
 {
-    #if use_int32
+#if use_int32
           using cInt = Int32;
-    #else
-        using cInt = Int64;
-    #endif
+#else
+    using cInt = Int64;
+#endif
 
     using Path = List<IntPoint>;
     using Paths = List<List<IntPoint>>;
@@ -169,15 +169,15 @@ namespace TVGL.Boolean_Operations.Clipper
         {
             Clear();
         }
-        
-        internal void Clear() 
+
+        internal void Clear()
         {
             for (var i = 0; i < MAllPolys.Count; i++)
                 MAllPolys[i] = null;
-            MAllPolys.Clear(); 
-            MChilds.Clear(); 
+            MAllPolys.Clear();
+            MChilds.Clear();
         }
-        
+
         internal PolyNode GetFirst()
         {
             if (MChilds.Count > 0)
@@ -187,8 +187,8 @@ namespace TVGL.Boolean_Operations.Clipper
 
         internal int Total
         {
-            get 
-            { 
+            get
+            {
                 var result = MAllPolys.Count;
                 //with negative offsets, ignore the hidden outer polygon ...
                 if (result > 0 && MChilds[0] != MAllPolys[0]) result--;
@@ -197,7 +197,7 @@ namespace TVGL.Boolean_Operations.Clipper
         }
     }
 
-    internal class PolyNode 
+    internal class PolyNode
     {
         internal PolyNode MParent;
         internal Path MPolygon = new Path();
@@ -238,10 +238,10 @@ namespace TVGL.Boolean_Operations.Clipper
 
         internal PolyNode GetNext()
         {
-            if (MChilds.Count > 0) 
-                return MChilds[0]; 
+            if (MChilds.Count > 0)
+                return MChilds[0];
             else
-                return GetNextSiblingUp();        
+                return GetNextSiblingUp();
         }
 
         internal PolyNode GetNextSiblingUp()
@@ -325,7 +325,7 @@ namespace TVGL.Boolean_Operations.Clipper
         public override bool Equals(Object obj)
         {
             if (!(obj is Int128))
-            return false;
+                return false;
             Int128 i128 = (Int128)obj;
             return (i128.hi == hi && i128.lo == lo);
         }
@@ -338,14 +338,14 @@ namespace TVGL.Boolean_Operations.Clipper
         public static bool operator >(Int128 val1, Int128 val2)
         {
             if (val1.hi != val2.hi)
-            return val1.hi > val2.hi;
+                return val1.hi > val2.hi;
             return val1.lo > val2.lo;
         }
 
         public static bool operator <(Int128 val1, Int128 val2)
         {
             if (val1.hi != val2.hi)
-            return val1.hi < val2.hi;
+                return val1.hi < val2.hi;
             return val1.lo < val2.lo;
         }
 
@@ -370,12 +370,12 @@ namespace TVGL.Boolean_Operations.Clipper
         public static explicit operator double(Int128 val)
         {
             const double shift64 = 18446744073709551616.0; //2^64
-            if (val.hi >= 0) return val.lo + val.hi*shift64;
+            if (val.hi >= 0) return val.lo + val.hi * shift64;
             if (val.lo == 0)
                 return val.hi * shift64;
             return -(~val.lo + ~val.hi * shift64);
         }
-    
+
         //nb: Constructing two new Int128 objects every time we want to multiply longs  
         //is slow. So, although calling the Int128Mul method doesn't look as clean, the 
         //code runs significantly faster than if we'd used the * operator.
@@ -436,7 +436,7 @@ namespace TVGL.Boolean_Operations.Clipper
 
         public static bool operator !=(IntPoint a, IntPoint b)
         {
-            return a.X != b.X  || a.Y != b.Y; 
+            return a.X != b.X || a.Y != b.Y;
         }
 
         public override bool Equals(object obj)
@@ -444,16 +444,16 @@ namespace TVGL.Boolean_Operations.Clipper
             if (obj == null) return false;
             if (obj is IntPoint)
             {
-            IntPoint a = (IntPoint)obj;
-            return (X == a.X) && (Y == a.Y);
+                IntPoint a = (IntPoint)obj;
+                return (X == a.X) && (Y == a.Y);
             }
             else return false;
         }
 
         public override int GetHashCode()
         {
-          //simply prevents a compiler warning
-          return base.GetHashCode();
+            //simply prevents a compiler warning
+            return base.GetHashCode();
         }
 
     }// end struct IntPoint
@@ -483,22 +483,22 @@ namespace TVGL.Boolean_Operations.Clipper
     #region Internal Enum Values
     internal enum ClipType { ctIntersection, ctUnion, ctDifference, ctXor };
     internal enum PolyType { ptSubject, ptClip };
-  
+
     //By far the most widely used winding rules for polygon filling are
     //EvenOdd & NonZero (GDI, GDI+, XLib, OpenGL, Cairo, AGG, Quartz, SVG, Gr32)
     //Others rules include Positive, Negative and ABS_GTR_EQ_TWO (only in OpenGL)
     //see http://glprogramming.com/red/chapter11.html
     internal enum PolyFillType { pftEvenOdd, pftNonZero, pftPositive, pftNegative };
-  
+
     internal enum JoinType { jtSquare, jtRound, jtMiter };
     internal enum EndType { etClosedPolygon, etClosedLine, etOpenButt, etOpenSquare, etOpenRound };
 
-    internal enum EdgeSide {esLeft, esRight};
-    internal enum Direction {dRightToLeft, dLeftToRight};
+    internal enum EdgeSide { esLeft, esRight };
+    internal enum Direction { dRightToLeft, dLeftToRight };
     #endregion
 
     #region T Edge Class
-    internal class TEdge 
+    internal class TEdge
     {
         internal IntPoint Bot;
         internal IntPoint Curr;
@@ -585,20 +585,20 @@ namespace TVGL.Boolean_Operations.Clipper
 
     #region ClipperBase Class
     internal class ClipperBase
-    {   
+    {
         protected const double Horizontal = -3.4E+38;
         protected const int Skip = -2;
         protected const int Unassigned = -1;
         protected const double Tolerance = 1.0E-20;
-        internal static bool near_zero(double val){return (val > -Tolerance) && (val < Tolerance);}
+        internal static bool near_zero(double val) { return (val > -Tolerance) && (val < Tolerance); }
 
-        #if use_int32
+#if use_int32
             internal const cInt loRange = 0x7FFF;
             internal const cInt hiRange = 0x7FFF;
-        #else
-            internal const long LoRange = 0x3FFFFFFF;
-            internal const long HiRange = 0x3FFFFFFFFFFFFFFFL; 
-        #endif
+#else
+        internal const long LoRange = 0x3FFFFFFF;
+        internal const long HiRange = 0x3FFFFFFFFFFFFFFFL;
+#endif
 
         internal LocalMinima MMinimaList;
         internal LocalMinima MCurrentLm;
@@ -611,7 +611,7 @@ namespace TVGL.Boolean_Operations.Clipper
             get;
             set;
         }
-    
+
         internal void Swap(ref long val1, ref long val2)
         {
             var tmp = val1;
@@ -629,23 +629,23 @@ namespace TVGL.Boolean_Operations.Clipper
             var pp2 = pp;
             do
             {
-            if (pp2.Pt == pt) return true;
-            pp2 = pp2.Next;
+                if (pp2.Pt == pt) return true;
+                pp2 = pp2.Next;
             }
             while (pp2 != pp);
             return false;
         }
 
-        internal bool PointOnLineSegment(IntPoint pt, 
+        internal bool PointOnLineSegment(IntPoint pt,
             IntPoint linePt1, IntPoint linePt2, bool useFullRange)
         {
             if (useFullRange)
-            return ((pt.X == linePt1.X) && (pt.Y == linePt1.Y)) ||
-                ((pt.X == linePt2.X) && (pt.Y == linePt2.Y)) ||
-                (((pt.X > linePt1.X) == (pt.X < linePt2.X)) &&
-                ((pt.Y > linePt1.Y) == (pt.Y < linePt2.Y)) &&
-                ((Int128.Int128Mul((pt.X - linePt1.X), (linePt2.Y - linePt1.Y)) ==
-                Int128.Int128Mul((linePt2.X - linePt1.X), (pt.Y - linePt1.Y)))));
+                return ((pt.X == linePt1.X) && (pt.Y == linePt1.Y)) ||
+                    ((pt.X == linePt2.X) && (pt.Y == linePt2.Y)) ||
+                    (((pt.X > linePt1.X) == (pt.X < linePt2.X)) &&
+                    ((pt.Y > linePt1.Y) == (pt.Y < linePt2.Y)) &&
+                    ((Int128.Int128Mul((pt.X - linePt1.X), (linePt2.Y - linePt1.Y)) ==
+                    Int128.Int128Mul((linePt2.X - linePt1.X), (pt.Y - linePt1.Y)))));
             return ((pt.X == linePt1.X) && (pt.Y == linePt1.Y)) ||
                    ((pt.X == linePt2.X) && (pt.Y == linePt2.Y)) ||
                    (((pt.X > linePt1.X) == (pt.X < linePt2.X)) &&
@@ -658,23 +658,23 @@ namespace TVGL.Boolean_Operations.Clipper
 
         internal bool PointOnPolygon(IntPoint pt, OutPt pp, bool UseFullRange)
         {
-          OutPt pp2 = pp;
-          while (true)
-          {
-            if (PointOnLineSegment(pt, pp2.Pt, pp2.Next.Pt, UseFullRange))
-              return true;
-            pp2 = pp2.Next;
-            if (pp2 == pp) break;
-          }
-          return false;
+            OutPt pp2 = pp;
+            while (true)
+            {
+                if (PointOnLineSegment(pt, pp2.Pt, pp2.Next.Pt, UseFullRange))
+                    return true;
+                pp2 = pp2.Next;
+                if (pp2 == pp) break;
+            }
+            return false;
         }
         //------------------------------------------------------------------------------
 
         internal static bool SlopesEqual(TEdge e1, TEdge e2, bool UseFullRange)
         {
             if (UseFullRange)
-              return Int128.Int128Mul(e1.Delta.Y, e2.Delta.X) ==
-                  Int128.Int128Mul(e1.Delta.X, e2.Delta.Y);
+                return Int128.Int128Mul(e1.Delta.Y, e2.Delta.X) ==
+                    Int128.Int128Mul(e1.Delta.X, e2.Delta.Y);
             else return (cInt)(e1.Delta.Y) * (e2.Delta.X) ==
               (cInt)(e1.Delta.X) * (e2.Delta.Y);
         }
@@ -700,7 +700,7 @@ namespace TVGL.Boolean_Operations.Clipper
             else return
               (cInt)(pt1.Y - pt2.Y) * (pt3.X - pt4.X) - (cInt)(pt1.X - pt2.X) * (pt3.Y - pt4.Y) == 0;
         }
-    
+
         internal ClipperBase() //constructor (nb: no external instantiation)
         {
             MMinimaList = null;
@@ -724,7 +724,7 @@ namespace TVGL.Boolean_Operations.Clipper
 
         private void DisposeLocalMinimaList()
         {
-            while( MMinimaList != null )
+            while (MMinimaList != null)
             {
                 LocalMinima tmpLm = MMinimaList.Next;
                 MMinimaList = null;
@@ -751,45 +751,45 @@ namespace TVGL.Boolean_Operations.Clipper
             }
         }
 
-          private static void InitEdge(TEdge e, TEdge eNext,
-          TEdge ePrev, IntPoint pt)
+        private static void InitEdge(TEdge e, TEdge eNext,
+        TEdge ePrev, IntPoint pt)
         {
-          e.Next = eNext;
-          e.Prev = ePrev;
-          e.Curr = pt;
-          e.OutIdx = Unassigned;
+            e.Next = eNext;
+            e.Prev = ePrev;
+            e.Curr = pt;
+            e.OutIdx = Unassigned;
         }
 
         private void InitEdge2(TEdge e, PolyType polyType)
         {
-          if (e.Curr.Y >= e.Next.Curr.Y)
-          {
-            e.Bot = e.Curr;
-            e.Top = e.Next.Curr;
-          }
-          else
-          {
-            e.Top = e.Curr;
-            e.Bot = e.Next.Curr;
-          }
-          SetDx(e);
-          e.PolyTyp = polyType;
+            if (e.Curr.Y >= e.Next.Curr.Y)
+            {
+                e.Bot = e.Curr;
+                e.Top = e.Next.Curr;
+            }
+            else
+            {
+                e.Top = e.Curr;
+                e.Bot = e.Next.Curr;
+            }
+            SetDx(e);
+            e.PolyTyp = polyType;
         }
 
         private static TEdge FindNextLocMin(TEdge E)
         {
             for (;;)
-          {
-            while (E.Bot != E.Prev.Bot || E.Curr == E.Top) E = E.Next;
-            if (E.Dx != Horizontal && E.Prev.Dx != Horizontal) break;
-            while (E.Prev.Dx == Horizontal) E = E.Prev;
-            var e2 = E;
-            while (E.Dx == Horizontal) E = E.Next;
-            if (E.Top.Y == E.Prev.Bot.Y) continue; //ie just an intermediate horz.
-            if (e2.Prev.Bot.X < E.Bot.X) E = e2;
-            break;
-          }
-          return E;
+            {
+                while (E.Bot != E.Prev.Bot || E.Curr == E.Top) E = E.Next;
+                if (E.Dx != Horizontal && E.Prev.Dx != Horizontal) break;
+                while (E.Prev.Dx == Horizontal) E = E.Prev;
+                var e2 = E;
+                while (E.Dx == Horizontal) E = E.Next;
+                if (E.Top.Y == E.Prev.Bot.Y) continue; //ie just an intermediate horz.
+                if (e2.Prev.Bot.X < E.Bot.X) E = e2;
+                break;
+            }
+            return E;
         }
 
         private TEdge ProcessBound(TEdge E, bool leftBoundIsForward)
@@ -799,415 +799,417 @@ namespace TVGL.Boolean_Operations.Clipper
 
             if (result.OutIdx == Skip)
             {
-            //check if there are edges beyond the skip edge in the bound and if so
-            //create another LocMin and calling ProcessBound once more ...
-            E = result;
-            if (leftBoundIsForward)
-            {
-                while (E.Top.Y == E.Next.Bot.Y) E = E.Next;
-                while (E != result && E.Dx == Horizontal) E = E.Prev;
-            }
-            else
-            {
-                while (E.Top.Y == E.Prev.Bot.Y) E = E.Prev;
-                while (E != result && E.Dx == Horizontal) E = E.Next;
-            }
-            if (E == result)
-            {
-                result = leftBoundIsForward ? E.Next : E.Prev;
-            }
-            else
-            {
-                //there are more edges in the bound beyond result starting with E
-                E = leftBoundIsForward ? result.Next : result.Prev;
-                var locMin = new LocalMinima
+                //check if there are edges beyond the skip edge in the bound and if so
+                //create another LocMin and calling ProcessBound once more ...
+                E = result;
+                if (leftBoundIsForward)
                 {
-                    Next = null,
-                    Y = E.Bot.Y,
-                    LeftBound = null,
-                    RightBound = E
-                };
-                E.WindDelta = 0;
+                    while (E.Top.Y == E.Next.Bot.Y) E = E.Next;
+                    while (E != result && E.Dx == Horizontal) E = E.Prev;
+                }
+                else
+                {
+                    while (E.Top.Y == E.Prev.Bot.Y) E = E.Prev;
+                    while (E != result && E.Dx == Horizontal) E = E.Next;
+                }
+                if (E == result)
+                {
+                    result = leftBoundIsForward ? E.Next : E.Prev;
+                }
+                else
+                {
+                    //there are more edges in the bound beyond result starting with E
+                    E = leftBoundIsForward ? result.Next : result.Prev;
+                    var locMin = new LocalMinima
+                    {
+                        Next = null,
+                        Y = E.Bot.Y,
+                        LeftBound = null,
+                        RightBound = E
+                    };
+                    E.WindDelta = 0;
                     result = ProcessBound(E, leftBoundIsForward);
                     InsertLocalMinima(locMin);
+                }
+                return result;
+            }
+
+            if (E.Dx == Horizontal)
+            {
+                //We need to be careful with open paths because this may not be a
+                //true local minima (ie E may be following a skip edge).
+                //Also, consecutive horz. edges may start heading left before going right.
+                if (leftBoundIsForward) eStart = E.Prev;
+                else eStart = E.Next;
+                if (eStart.OutIdx != Skip)
+                {
+                    if (eStart.Dx == Horizontal) //ie an adjoining horizontal skip edge
+                    {
+                        if (eStart.Bot.X != E.Bot.X && eStart.Top.X != E.Bot.X)
+                            ReverseHorizontal(E);
+                    }
+                    else if (eStart.Bot.X != E.Bot.X)
+                        ReverseHorizontal(E);
+                }
+            }
+
+            eStart = E;
+            if (leftBoundIsForward)
+            {
+                while (result.Top.Y == result.Next.Bot.Y && result.Next.OutIdx != Skip)
+                    result = result.Next;
+                if (result.Dx == Horizontal && result.Next.OutIdx != Skip)
+                {
+                    //nb: at the top of a bound, horizontals are added to the bound
+                    //only when the preceding edge attaches to the horizontal's left vertex
+                    //unless a Skip edge is encountered when that becomes the top divide
+                    horz = result;
+                    while (horz.Prev.Dx == Horizontal) horz = horz.Prev;
+                    if (horz.Prev.Top.X == result.Next.Top.X)
+                    {
+                        if (!leftBoundIsForward) result = horz.Prev;
+                    }
+                    else if (horz.Prev.Top.X > result.Next.Top.X) result = horz.Prev;
+                }
+                while (E != result)
+                {
+                    E.NextInLML = E.Next;
+                    if (E.Dx == Horizontal && E != eStart && E.Bot.X != E.Prev.Top.X)
+                        ReverseHorizontal(E);
+                    E = E.Next;
+                }
+                if (E.Dx == Horizontal && E != eStart && E.Bot.X != E.Prev.Top.X)
+                    ReverseHorizontal(E);
+                result = result.Next; //move to the edge just beyond current bound
+            }
+            else
+            {
+                while (result.Top.Y == result.Prev.Bot.Y && result.Prev.OutIdx != Skip)
+                    result = result.Prev;
+                if (result.Dx == Horizontal && result.Prev.OutIdx != Skip)
+                {
+                    horz = result;
+                    while (horz.Next.Dx == Horizontal) horz = horz.Next;
+                    if (horz.Next.Top.X == result.Prev.Top.X)
+                    {
+                        if (!leftBoundIsForward) result = horz.Next;
+                    }
+                    else if (horz.Next.Top.X > result.Prev.Top.X) result = horz.Next;
+                }
+
+                while (E != result)
+                {
+                    E.NextInLML = E.Prev;
+                    if (E.Dx == Horizontal && E != eStart && E.Bot.X != E.Next.Top.X)
+                        ReverseHorizontal(E);
+                    E = E.Prev;
+                }
+                if (E.Dx == Horizontal && E != eStart && E.Bot.X != E.Next.Top.X)
+                    ReverseHorizontal(E);
+                result = result.Prev; //move to the edge just beyond current bound
             }
             return result;
         }
-
-        if (E.Dx == Horizontal)
-        {
-            //We need to be careful with open paths because this may not be a
-            //true local minima (ie E may be following a skip edge).
-            //Also, consecutive horz. edges may start heading left before going right.
-            if (leftBoundIsForward) eStart = E.Prev;
-            else eStart = E.Next;
-            if (eStart.OutIdx != Skip)
-            {
-                if (eStart.Dx == Horizontal) //ie an adjoining horizontal skip edge
-                {
-                if (eStart.Bot.X != E.Bot.X && eStart.Top.X != E.Bot.X)
-                    ReverseHorizontal(E);
-                }
-                else if (eStart.Bot.X != E.Bot.X)
-                ReverseHorizontal(E);
-            }
-        }
-
-        eStart = E;
-        if (leftBoundIsForward)
-        {
-        while (result.Top.Y == result.Next.Bot.Y && result.Next.OutIdx != Skip)
-            result = result.Next;
-        if (result.Dx == Horizontal && result.Next.OutIdx != Skip)
-        {
-            //nb: at the top of a bound, horizontals are added to the bound
-            //only when the preceding edge attaches to the horizontal's left vertex
-            //unless a Skip edge is encountered when that becomes the top divide
-            horz = result;
-            while (horz.Prev.Dx == Horizontal) horz = horz.Prev;
-            if (horz.Prev.Top.X == result.Next.Top.X)
-            {
-            if (!leftBoundIsForward) result = horz.Prev;
-            }
-            else if (horz.Prev.Top.X > result.Next.Top.X) result = horz.Prev;
-        }
-        while (E != result)
-        {
-            E.NextInLML = E.Next;
-            if (E.Dx == Horizontal && E != eStart && E.Bot.X != E.Prev.Top.X) 
-            ReverseHorizontal(E);
-            E = E.Next;
-        }
-        if (E.Dx == Horizontal && E != eStart && E.Bot.X != E.Prev.Top.X) 
-            ReverseHorizontal(E);
-        result = result.Next; //move to the edge just beyond current bound
-        }
-        else
-        {
-        while (result.Top.Y == result.Prev.Bot.Y && result.Prev.OutIdx != Skip)
-            result = result.Prev;
-        if (result.Dx == Horizontal && result.Prev.OutIdx != Skip)
-        {
-            horz = result;
-            while (horz.Next.Dx == Horizontal) horz = horz.Next;
-            if (horz.Next.Top.X == result.Prev.Top.X)
-            {
-            if (!leftBoundIsForward) result = horz.Next;
-            }
-            else if (horz.Next.Top.X > result.Prev.Top.X) result = horz.Next;
-        }
-
-        while (E != result)
-        {
-            E.NextInLML = E.Prev;
-            if (E.Dx == Horizontal && E != eStart && E.Bot.X != E.Next.Top.X) 
-            ReverseHorizontal(E);
-            E = E.Prev;
-        }
-        if (E.Dx == Horizontal && E != eStart && E.Bot.X != E.Next.Top.X) 
-            ReverseHorizontal(E);
-        result = result.Prev; //move to the edge just beyond current bound
-        }
-        return result;
-    }
-    //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
 
-    internal bool AddPath(Path pg, PolyType polyType, bool Closed)
-    {
+        internal bool AddPath(Path pg, PolyType polyType, bool Closed)
+        {
 #if use_lines
       if (!Closed && polyType == PolyType.ptClip)
         throw new ClipperException("AddPath: Open paths must be subject.");
 #else
-      if (!Closed)
-        throw new ClipperException("AddPath: Open paths have been disabled.");
+            if (!Closed)
+                throw new ClipperException("AddPath: Open paths have been disabled.");
 #endif
 
-      int highI = (int)pg.Count - 1;
-      if (Closed) while (highI > 0 && (pg[highI] == pg[0])) --highI;
-      while (highI > 0 && (pg[highI] == pg[highI - 1])) --highI;
-      if ((Closed && highI < 2) || (!Closed && highI < 1)) return false;
+            int highI = (int)pg.Count - 1;
+            if (Closed) while (highI > 0 && (pg[highI] == pg[0])) --highI;
+            while (highI > 0 && (pg[highI] == pg[highI - 1])) --highI;
+            if ((Closed && highI < 2) || (!Closed && highI < 1)) return false;
 
-      //create a new edge array ...
-      List<TEdge> edges = new List<TEdge>(highI+1);
-      for (int i = 0; i <= highI; i++) edges.Add(new TEdge());
-          
-      bool IsFlat = true;
+            //create a new edge array ...
+            List<TEdge> edges = new List<TEdge>(highI + 1);
+            for (int i = 0; i <= highI; i++) edges.Add(new TEdge());
 
-      //1. Basic (first) edge initialization ...
-      edges[1].Curr = pg[1];
-      RangeTest(pg[0], ref MUseFullRange);
-      RangeTest(pg[highI], ref MUseFullRange);
-      InitEdge(edges[0], edges[1], edges[highI], pg[0]);
-      InitEdge(edges[highI], edges[0], edges[highI - 1], pg[highI]);
-      for (int i = highI - 1; i >= 1; --i)
-      {
-        RangeTest(pg[i], ref MUseFullRange);
-        InitEdge(edges[i], edges[i + 1], edges[i - 1], pg[i]);
-      }
-      TEdge eStart = edges[0];
+            bool IsFlat = true;
 
-      //2. Remove duplicate vertices, and (when closed) collinear edges ...
-      TEdge E = eStart, eLoopStop = eStart;
-      for (;;)
-      {
-        //nb: allows matching start and end points when not Closed ...
-        if (E.Curr == E.Next.Curr && (Closed || E.Next != eStart))
-        {
-          if (E == E.Next) break;
-          if (E == eStart) eStart = E.Next;
-          E = RemoveEdge(E);
-          eLoopStop = E;
-          continue;
+            //1. Basic (first) edge initialization ...
+            edges[1].Curr = pg[1];
+            RangeTest(pg[0], ref MUseFullRange);
+            RangeTest(pg[highI], ref MUseFullRange);
+            InitEdge(edges[0], edges[1], edges[highI], pg[0]);
+            InitEdge(edges[highI], edges[0], edges[highI - 1], pg[highI]);
+            for (int i = highI - 1; i >= 1; --i)
+            {
+                RangeTest(pg[i], ref MUseFullRange);
+                InitEdge(edges[i], edges[i + 1], edges[i - 1], pg[i]);
+            }
+            TEdge eStart = edges[0];
+
+            //2. Remove duplicate vertices, and (when closed) collinear edges ...
+            TEdge E = eStart, eLoopStop = eStart;
+            for (;;)
+            {
+                //nb: allows matching start and end points when not Closed ...
+                if (E.Curr == E.Next.Curr && (Closed || E.Next != eStart))
+                {
+                    if (E == E.Next) break;
+                    if (E == eStart) eStart = E.Next;
+                    E = RemoveEdge(E);
+                    eLoopStop = E;
+                    continue;
+                }
+                if (E.Prev == E.Next)
+                    break; //only two vertices
+                else if (Closed &&
+                  SlopesEqual(E.Prev.Curr, E.Curr, E.Next.Curr, MUseFullRange) &&
+                  (!PreserveCollinear ||
+                  !Pt2IsBetweenPt1AndPt3(E.Prev.Curr, E.Curr, E.Next.Curr)))
+                {
+                    //Collinear edges are allowed for open paths but in closed paths
+                    //the default is to merge adjacent collinear edges into a single edge.
+                    //However, if the PreserveCollinear property is enabled, only overlapping
+                    //collinear edges (ie spikes) will be removed from closed paths.
+                    if (E == eStart) eStart = E.Next;
+                    E = RemoveEdge(E);
+                    E = E.Prev;
+                    eLoopStop = E;
+                    continue;
+                }
+                E = E.Next;
+                if ((E == eLoopStop) || (!Closed && E.Next == eStart)) break;
+            }
+
+            if ((!Closed && (E == E.Next)) || (Closed && (E.Prev == E.Next)))
+                return false;
+
+            if (!Closed)
+            {
+                MHasOpenPaths = true;
+                eStart.Prev.OutIdx = Skip;
+            }
+
+            //3. Do second stage of edge initialization ...
+            E = eStart;
+            do
+            {
+                InitEdge2(E, polyType);
+                E = E.Next;
+                if (IsFlat && E.Curr.Y != eStart.Curr.Y) IsFlat = false;
+            }
+            while (E != eStart);
+
+            //4. Finally, add edge bounds to LocalMinima list ...
+
+            //Totally flat paths must be handled differently when adding them
+            //to LocalMinima list to avoid endless loops etc ...
+            if (IsFlat)
+            {
+                if (Closed) return false;
+                E.Prev.OutIdx = Skip;
+                if (E.Prev.Bot.X < E.Prev.Top.X) ReverseHorizontal(E.Prev);
+                LocalMinima locMin = new LocalMinima();
+                locMin.Next = null;
+                locMin.Y = E.Bot.Y;
+                locMin.LeftBound = null;
+                locMin.RightBound = E;
+                locMin.RightBound.Side = EdgeSide.esRight;
+                locMin.RightBound.WindDelta = 0;
+                while (E.Next.OutIdx != Skip)
+                {
+                    E.NextInLML = E.Next;
+                    if (E.Bot.X != E.Prev.Top.X) ReverseHorizontal(E);
+                    E = E.Next;
+                }
+                InsertLocalMinima(locMin);
+                MEdges.Add(edges);
+                return true;
+            }
+
+            MEdges.Add(edges);
+            bool leftBoundIsForward;
+            TEdge EMin = null;
+
+            //workaround to avoid an endless loop in the while loop below when
+            //open paths have matching start and end points ...
+            if (E.Prev.Bot == E.Prev.Top) E = E.Next;
+
+            for (;;)
+            {
+                E = FindNextLocMin(E);
+                if (E == EMin) break;
+                else if (EMin == null) EMin = E;
+
+                //E and E.Prev now share a local minima (left aligned if horizontal).
+                //Compare their slopes to find which starts which bound ...
+                LocalMinima locMin = new LocalMinima();
+                locMin.Next = null;
+                locMin.Y = E.Bot.Y;
+                if (E.Dx < E.Prev.Dx)
+                {
+                    locMin.LeftBound = E.Prev;
+                    locMin.RightBound = E;
+                    leftBoundIsForward = false; //Q.nextInLML = Q.prev
+                }
+                else
+                {
+                    locMin.LeftBound = E;
+                    locMin.RightBound = E.Prev;
+                    leftBoundIsForward = true; //Q.nextInLML = Q.next
+                }
+                locMin.LeftBound.Side = EdgeSide.esLeft;
+                locMin.RightBound.Side = EdgeSide.esRight;
+
+                if (!Closed) locMin.LeftBound.WindDelta = 0;
+                else if (locMin.LeftBound.Next == locMin.RightBound)
+                    locMin.LeftBound.WindDelta = -1;
+                else locMin.LeftBound.WindDelta = 1;
+                locMin.RightBound.WindDelta = -locMin.LeftBound.WindDelta;
+
+                E = ProcessBound(locMin.LeftBound, leftBoundIsForward);
+                if (E.OutIdx == Skip) E = ProcessBound(E, leftBoundIsForward);
+
+                TEdge E2 = ProcessBound(locMin.RightBound, !leftBoundIsForward);
+                if (E2.OutIdx == Skip) E2 = ProcessBound(E2, !leftBoundIsForward);
+
+                if (locMin.LeftBound.OutIdx == Skip)
+                    locMin.LeftBound = null;
+                else if (locMin.RightBound.OutIdx == Skip)
+                    locMin.RightBound = null;
+                InsertLocalMinima(locMin);
+                if (!leftBoundIsForward) E = E2;
+            }
+            return true;
+
         }
-        if (E.Prev == E.Next) 
-          break; //only two vertices
-        else if (Closed &&
-          SlopesEqual(E.Prev.Curr, E.Curr, E.Next.Curr, MUseFullRange) && 
-          (!PreserveCollinear ||
-          !Pt2IsBetweenPt1AndPt3(E.Prev.Curr, E.Curr, E.Next.Curr))) 
+        //------------------------------------------------------------------------------
+
+        internal bool AddPaths(Paths ppg, PolyType polyType, bool closed)
         {
-          //Collinear edges are allowed for open paths but in closed paths
-          //the default is to merge adjacent collinear edges into a single edge.
-          //However, if the PreserveCollinear property is enabled, only overlapping
-          //collinear edges (ie spikes) will be removed from closed paths.
-          if (E == eStart) eStart = E.Next;
-          E = RemoveEdge(E);
-          E = E.Prev;
-          eLoopStop = E;
-          continue;
+            bool result = false;
+            for (int i = 0; i < ppg.Count; ++i)
+                if (AddPath(ppg[i], polyType, closed)) result = true;
+            return result;
         }
-        E = E.Next;
-        if ((E == eLoopStop) || (!Closed && E.Next == eStart)) break;
-      }
+        //------------------------------------------------------------------------------
 
-      if ((!Closed && (E == E.Next)) || (Closed && (E.Prev == E.Next)))
-        return false;
-
-      if (!Closed)
-      {
-        MHasOpenPaths = true;
-        eStart.Prev.OutIdx = Skip;
-      }
-
-      //3. Do second stage of edge initialization ...
-      E = eStart;
-      do
-      {
-        InitEdge2(E, polyType);
-        E = E.Next;
-        if (IsFlat && E.Curr.Y != eStart.Curr.Y) IsFlat = false;
-      }
-      while (E != eStart);
-
-      //4. Finally, add edge bounds to LocalMinima list ...
-
-      //Totally flat paths must be handled differently when adding them
-      //to LocalMinima list to avoid endless loops etc ...
-      if (IsFlat) 
-      {
-        if (Closed) return false;
-        E.Prev.OutIdx = Skip;
-        if (E.Prev.Bot.X < E.Prev.Top.X) ReverseHorizontal(E.Prev);
-        LocalMinima locMin = new LocalMinima();
-        locMin.Next = null;
-        locMin.Y = E.Bot.Y;
-        locMin.LeftBound = null;
-        locMin.RightBound = E;
-        locMin.RightBound.Side = EdgeSide.esRight;
-        locMin.RightBound.WindDelta = 0;
-        while (E.Next.OutIdx != Skip)
+        internal bool Pt2IsBetweenPt1AndPt3(IntPoint pt1, IntPoint pt2, IntPoint pt3)
         {
-          E.NextInLML = E.Next;
-          if (E.Bot.X != E.Prev.Top.X) ReverseHorizontal(E);
-          E = E.Next;
+            if ((pt1 == pt3) || (pt1 == pt2) || (pt3 == pt2)) return false;
+            else if (pt1.X != pt3.X) return (pt2.X > pt1.X) == (pt2.X < pt3.X);
+            else return (pt2.Y > pt1.Y) == (pt2.Y < pt3.Y);
         }
-        InsertLocalMinima(locMin);
-        MEdges.Add(edges);
-        return true;
-      }
+        //------------------------------------------------------------------------------
 
-      MEdges.Add(edges);
-      bool leftBoundIsForward;
-      TEdge EMin = null;
-
-      //workaround to avoid an endless loop in the while loop below when
-      //open paths have matching start and end points ...
-      if (E.Prev.Bot == E.Prev.Top) E = E.Next;
-
-      for (;;)
-      {
-        E = FindNextLocMin(E);
-        if (E == EMin) break;
-        else if (EMin == null) EMin = E;
-
-        //E and E.Prev now share a local minima (left aligned if horizontal).
-        //Compare their slopes to find which starts which bound ...
-        LocalMinima locMin = new LocalMinima();
-        locMin.Next = null;
-        locMin.Y = E.Bot.Y;
-        if (E.Dx < E.Prev.Dx) 
+        TEdge RemoveEdge(TEdge e)
         {
-          locMin.LeftBound = E.Prev;
-          locMin.RightBound = E;
-          leftBoundIsForward = false; //Q.nextInLML = Q.prev
-        } else
-        {
-          locMin.LeftBound = E;
-          locMin.RightBound = E.Prev;
-          leftBoundIsForward = true; //Q.nextInLML = Q.next
+            //removes e from double_linked_list (but without removing from memory)
+            e.Prev.Next = e.Next;
+            e.Next.Prev = e.Prev;
+            TEdge result = e.Next;
+            e.Prev = null; //flag as removed (see ClipperBase.Clear)
+            return result;
         }
-        locMin.LeftBound.Side = EdgeSide.esLeft;
-        locMin.RightBound.Side = EdgeSide.esRight;
+        //------------------------------------------------------------------------------
 
-        if (!Closed) locMin.LeftBound.WindDelta = 0;
-        else if (locMin.LeftBound.Next == locMin.RightBound)
-          locMin.LeftBound.WindDelta = -1;
-        else locMin.LeftBound.WindDelta = 1;
-        locMin.RightBound.WindDelta = -locMin.LeftBound.WindDelta;
+        private void SetDx(TEdge e)
+        {
+            e.Delta.X = (e.Top.X - e.Bot.X);
+            e.Delta.Y = (e.Top.Y - e.Bot.Y);
+            if (e.Delta.Y == 0) e.Dx = Horizontal;
+            else e.Dx = (double)(e.Delta.X) / (e.Delta.Y);
+        }
+        //---------------------------------------------------------------------------
 
-        E = ProcessBound(locMin.LeftBound, leftBoundIsForward);
-        if (E.OutIdx == Skip) E = ProcessBound(E, leftBoundIsForward);
+        private void InsertLocalMinima(LocalMinima newLm)
+        {
+            if (MMinimaList == null)
+            {
+                MMinimaList = newLm;
+            }
+            else if (newLm.Y >= MMinimaList.Y)
+            {
+                newLm.Next = MMinimaList;
+                MMinimaList = newLm;
+            }
+            else
+            {
+                LocalMinima tmpLm = MMinimaList;
+                while (tmpLm.Next != null && (newLm.Y < tmpLm.Next.Y))
+                    tmpLm = tmpLm.Next;
+                newLm.Next = tmpLm.Next;
+                tmpLm.Next = newLm;
+            }
+        }
+        //------------------------------------------------------------------------------
 
-        TEdge E2 = ProcessBound(locMin.RightBound, !leftBoundIsForward);
-        if (E2.OutIdx == Skip) E2 = ProcessBound(E2, !leftBoundIsForward);
+        protected void PopLocalMinima()
+        {
+            if (MCurrentLm == null) return;
+            MCurrentLm = MCurrentLm.Next;
+        }
+        //------------------------------------------------------------------------------
 
-        if (locMin.LeftBound.OutIdx == Skip)
-          locMin.LeftBound = null;
-        else if (locMin.RightBound.OutIdx == Skip)
-          locMin.RightBound = null;
-        InsertLocalMinima(locMin);
-        if (!leftBoundIsForward) E = E2;
-      }
-      return true;
-
-    }
-    //------------------------------------------------------------------------------
-
-    internal bool AddPaths(Paths ppg, PolyType polyType, bool closed)
-    {
-      bool result = false;
-      for (int i = 0; i < ppg.Count; ++i)
-        if (AddPath(ppg[i], polyType, closed)) result = true;
-      return result;
-    }
-    //------------------------------------------------------------------------------
-
-    internal bool Pt2IsBetweenPt1AndPt3(IntPoint pt1, IntPoint pt2, IntPoint pt3)
-    {
-      if ((pt1 == pt3) || (pt1 == pt2) || (pt3 == pt2)) return false;
-      else if (pt1.X != pt3.X) return (pt2.X > pt1.X) == (pt2.X < pt3.X);
-      else return (pt2.Y > pt1.Y) == (pt2.Y < pt3.Y);
-    }
-    //------------------------------------------------------------------------------
-
-    TEdge RemoveEdge(TEdge e)
-    {
-      //removes e from double_linked_list (but without removing from memory)
-      e.Prev.Next = e.Next;
-      e.Next.Prev = e.Prev;
-      TEdge result = e.Next;
-      e.Prev = null; //flag as removed (see ClipperBase.Clear)
-      return result;
-    }
-    //------------------------------------------------------------------------------
-
-    private void SetDx(TEdge e)
-    {
-      e.Delta.X = (e.Top.X - e.Bot.X);
-      e.Delta.Y = (e.Top.Y - e.Bot.Y);
-      if (e.Delta.Y == 0) e.Dx = Horizontal;
-      else e.Dx = (double)(e.Delta.X) / (e.Delta.Y);
-    }
-    //---------------------------------------------------------------------------
-
-    private void InsertLocalMinima(LocalMinima newLm)
-    {
-      if( MMinimaList == null )
-      {
-        MMinimaList = newLm;
-      }
-      else if( newLm.Y >= MMinimaList.Y )
-      {
-        newLm.Next = MMinimaList;
-        MMinimaList = newLm;
-      } else
-      {
-        LocalMinima tmpLm = MMinimaList;
-        while( tmpLm.Next != null  && ( newLm.Y < tmpLm.Next.Y ) )
-          tmpLm = tmpLm.Next;
-        newLm.Next = tmpLm.Next;
-        tmpLm.Next = newLm;
-      }
-    }
-    //------------------------------------------------------------------------------
-
-    protected void PopLocalMinima()
-    {
-        if (MCurrentLm == null) return;
-        MCurrentLm = MCurrentLm.Next;
-    }
-    //------------------------------------------------------------------------------
-
-    private void ReverseHorizontal(TEdge e)
-    {
-      //swap horizontal edges' top and bottom x's so they follow the natural
-      //progression of the bounds - ie so their xbots will align with the
-      //adjoining lower edge. [Helpful in the ProcessHorizontal() method.]
-      Swap(ref e.Top.X, ref e.Bot.X);
+        private void ReverseHorizontal(TEdge e)
+        {
+            //swap horizontal edges' top and bottom x's so they follow the natural
+            //progression of the bounds - ie so their xbots will align with the
+            //adjoining lower edge. [Helpful in the ProcessHorizontal() method.]
+            Swap(ref e.Top.X, ref e.Bot.X);
 #if use_xyz
       Swap(ref e.Top.Z, ref e.Bot.Z);
 #endif
-    }
-    //------------------------------------------------------------------------------
-
-    protected virtual void Reset()
-    {
-      MCurrentLm = MMinimaList;
-      if (MCurrentLm == null) return; //ie nothing to process
-
-      //reset all edges ...
-      LocalMinima lm = MMinimaList;
-      while (lm != null)
-      {
-        TEdge e = lm.LeftBound;
-        if (e != null)
-        {
-          e.Curr = e.Bot;
-          e.Side = EdgeSide.esLeft;
-          e.OutIdx = Unassigned;
         }
-        e = lm.RightBound;
-        if (e != null)
+        //------------------------------------------------------------------------------
+
+        protected virtual void Reset()
         {
-          e.Curr = e.Bot;
-          e.Side = EdgeSide.esRight;
-          e.OutIdx = Unassigned;
+            MCurrentLm = MMinimaList;
+            if (MCurrentLm == null) return; //ie nothing to process
+
+            //reset all edges ...
+            LocalMinima lm = MMinimaList;
+            while (lm != null)
+            {
+                TEdge e = lm.LeftBound;
+                if (e != null)
+                {
+                    e.Curr = e.Bot;
+                    e.Side = EdgeSide.esLeft;
+                    e.OutIdx = Unassigned;
+                }
+                e = lm.RightBound;
+                if (e != null)
+                {
+                    e.Curr = e.Bot;
+                    e.Side = EdgeSide.esRight;
+                    e.OutIdx = Unassigned;
+                }
+                lm = lm.Next;
+            }
         }
-        lm = lm.Next;
-      }
-    }
-    //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
         internal static IntRect GetBounds(Paths paths)
         {
-          int i = 0, cnt = paths.Count;
-          while (i < cnt && paths[i].Count == 0) i++;
-          if (i == cnt) return new IntRect(0,0,0,0);
-          IntRect result = new IntRect();
-          result.left = paths[i][0].X;
-          result.right = result.left;
-          result.top = paths[i][0].Y;
-          result.bottom = result.top;
-          for (; i < cnt; i++)
-            for (int j = 0; j < paths[i].Count; j++)
-            {
-              if (paths[i][j].X < result.left) result.left = paths[i][j].X;
-              else if (paths[i][j].X > result.right) result.right = paths[i][j].X;
-              if (paths[i][j].Y < result.top) result.top = paths[i][j].Y;
-              else if (paths[i][j].Y > result.bottom) result.bottom = paths[i][j].Y;
-            }
-          return result;
+            int i = 0, cnt = paths.Count;
+            while (i < cnt && paths[i].Count == 0) i++;
+            if (i == cnt) return new IntRect(0, 0, 0, 0);
+            IntRect result = new IntRect();
+            result.left = paths[i][0].X;
+            result.right = result.left;
+            result.top = paths[i][0].Y;
+            result.bottom = result.top;
+            for (; i < cnt; i++)
+                for (int j = 0; j < paths[i].Count; j++)
+                {
+                    if (paths[i][j].X < result.left) result.left = paths[i][j].X;
+                    else if (paths[i][j].X > result.right) result.right = paths[i][j].X;
+                    if (paths[i][j].Y < result.top) result.top = paths[i][j].Y;
+                    else if (paths[i][j].Y > result.bottom) result.bottom = paths[i][j].Y;
+                }
+            return result;
         }
 
     } //end ClipperBase
@@ -1215,291 +1217,294 @@ namespace TVGL.Boolean_Operations.Clipper
 
     #region Clipper Class
     internal class Clipper : ClipperBase
-  {
-      //InitOptions that can be passed to the constructor ...
-      internal const int ioReverseSolution = 1;
-      internal const int ioStrictlySimple = 2;
-      internal const int ioPreserveCollinear = 4;
+    {
+        //InitOptions that can be passed to the constructor ...
+        internal const int ioReverseSolution = 1;
+        internal const int ioStrictlySimple = 2;
+        internal const int ioPreserveCollinear = 4;
 
-      private List<OutRec> m_PolyOuts;
-      private ClipType m_ClipType;
-      private Scanbeam m_Scanbeam;
-      private TEdge m_ActiveEdges;
-      private TEdge m_SortedEdges;
-      private List<IntersectNode> m_IntersectList;
-      IComparer<IntersectNode> m_IntersectNodeComparer;
-      private bool m_ExecuteLocked;
-      private PolyFillType m_ClipFillType;
-      private PolyFillType m_SubjFillType;
-      private List<Join> m_Joins;
-      private List<Join> m_GhostJoins;
-      private bool m_UsingPolyTree;
+        private List<OutRec> m_PolyOuts;
+        private ClipType m_ClipType;
+        private Scanbeam m_Scanbeam;
+        private TEdge m_ActiveEdges;
+        private TEdge m_SortedEdges;
+        private List<IntersectNode> m_IntersectList;
+        IComparer<IntersectNode> m_IntersectNodeComparer;
+        private bool m_ExecuteLocked;
+        private PolyFillType m_ClipFillType;
+        private PolyFillType m_SubjFillType;
+        private List<Join> m_Joins;
+        private List<Join> m_GhostJoins;
+        private bool m_UsingPolyTree;
 #if use_xyz
       internal delegate void ZFillCallback(IntPoint bot1, IntPoint top1, 
         IntPoint bot2, IntPoint top2, ref IntPoint pt);
       internal ZFillCallback ZFillFunction { get; set; }
 #endif
-      internal Clipper(int InitOptions = 0): base() //constructor
-      {
-          m_Scanbeam = null;
-          m_ActiveEdges = null;
-          m_SortedEdges = null;
-          m_IntersectList = new List<IntersectNode>();
-          m_IntersectNodeComparer = new MyIntersectNodeSort();
-          m_ExecuteLocked = false;
-          m_UsingPolyTree = false;
-          m_PolyOuts = new List<OutRec>();
-          m_Joins = new List<Join>();
-          m_GhostJoins = new List<Join>();
-          ReverseSolution = (ioReverseSolution & InitOptions) != 0;
-          StrictlySimple = (ioStrictlySimple & InitOptions) != 0;
-          PreserveCollinear = (ioPreserveCollinear & InitOptions) != 0;
+        internal Clipper(int InitOptions = 0) : base() //constructor
+        {
+            m_Scanbeam = null;
+            m_ActiveEdges = null;
+            m_SortedEdges = null;
+            m_IntersectList = new List<IntersectNode>();
+            m_IntersectNodeComparer = new MyIntersectNodeSort();
+            m_ExecuteLocked = false;
+            m_UsingPolyTree = false;
+            m_PolyOuts = new List<OutRec>();
+            m_Joins = new List<Join>();
+            m_GhostJoins = new List<Join>();
+            ReverseSolution = (ioReverseSolution & InitOptions) != 0;
+            StrictlySimple = (ioStrictlySimple & InitOptions) != 0;
+            PreserveCollinear = (ioPreserveCollinear & InitOptions) != 0;
 #if use_xyz
           ZFillFunction = null;
 #endif
-      }
-      //------------------------------------------------------------------------------
-
-      void DisposeScanbeamList()
-      {
-        while ( m_Scanbeam != null ) {
-        Scanbeam sb2 = m_Scanbeam.Next;
-        m_Scanbeam = null;
-        m_Scanbeam = sb2;
         }
-      }
-      //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-      protected override void Reset() 
-      {
-        base.Reset();
-        m_Scanbeam = null;
-        m_ActiveEdges = null;
-        m_SortedEdges = null;
-        LocalMinima lm = MMinimaList;
-        while (lm != null)
+        void DisposeScanbeamList()
         {
-          InsertScanbeam(lm.Y);
-          lm = lm.Next;
+            while (m_Scanbeam != null)
+            {
+                Scanbeam sb2 = m_Scanbeam.Next;
+                m_Scanbeam = null;
+                m_Scanbeam = sb2;
+            }
         }
-      }
-      //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-      internal bool ReverseSolution
-      {
-        get;
-        set;
-      }
-      //------------------------------------------------------------------------------
-
-      internal bool StrictlySimple
-      {
-        get; 
-        set;
-      }
-      //------------------------------------------------------------------------------
-       
-      private void InsertScanbeam(cInt Y)
-      {
-        if( m_Scanbeam == null )
+        protected override void Reset()
         {
-          m_Scanbeam = new Scanbeam();
-          m_Scanbeam.Next = null;
-          m_Scanbeam.Y = Y;
+            base.Reset();
+            m_Scanbeam = null;
+            m_ActiveEdges = null;
+            m_SortedEdges = null;
+            LocalMinima lm = MMinimaList;
+            while (lm != null)
+            {
+                InsertScanbeam(lm.Y);
+                lm = lm.Next;
+            }
         }
-        else if(  Y > m_Scanbeam.Y )
+        //------------------------------------------------------------------------------
+
+        internal bool ReverseSolution
         {
-          Scanbeam newSb = new Scanbeam();
-          newSb.Y = Y;
-          newSb.Next = m_Scanbeam;
-          m_Scanbeam = newSb;
-        } else
-        {
-          Scanbeam sb2 = m_Scanbeam;
-          while( sb2.Next != null  && ( Y <= sb2.Next.Y ) ) sb2 = sb2.Next;
-          if(  Y == sb2.Y ) return; //ie ignores duplicates
-          Scanbeam newSb = new Scanbeam();
-          newSb.Y = Y;
-          newSb.Next = sb2.Next;
-          sb2.Next = newSb;
+            get;
+            set;
         }
-      }
-      //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-      internal bool Execute(ClipType clipType, Paths solution,
-          PolyFillType subjFillType, PolyFillType clipFillType)
-      {
-          if (m_ExecuteLocked) return false;
-          if (MHasOpenPaths) throw 
-            new ClipperException("Error: PolyTree struct is need for open path clipping.");
-
-          m_ExecuteLocked = true;
-          solution.Clear();
-          m_SubjFillType = subjFillType;
-          m_ClipFillType = clipFillType;
-          m_ClipType = clipType;
-          m_UsingPolyTree = false;
-          bool succeeded;
-          try
-          {
-            succeeded = ExecuteInternal();
-            //build the return polygons ...
-            if (succeeded) BuildResult(solution);
-          }
-          finally
-          {
-            DisposeAllPolyPts();
-            m_ExecuteLocked = false;
-          }
-          return succeeded;
-      }
-      //------------------------------------------------------------------------------
-
-      internal bool Execute(ClipType clipType, PolyTree polytree,
-          PolyFillType subjFillType, PolyFillType clipFillType)
-      {
-          if (m_ExecuteLocked) return false;
-          m_ExecuteLocked = true;
-          m_SubjFillType = subjFillType;
-          m_ClipFillType = clipFillType;
-          m_ClipType = clipType;
-          m_UsingPolyTree = true;
-          bool succeeded;
-          try
-          {
-            succeeded = ExecuteInternal();
-            //build the return polygons ...
-            if (succeeded) BuildResult2(polytree);
-          }
-          finally
-          {
-            DisposeAllPolyPts();
-            m_ExecuteLocked = false;
-          }
-          return succeeded;
-      }
-      //------------------------------------------------------------------------------
-
-      internal bool Execute(ClipType clipType, Paths solution)
-      {
-          return Execute(clipType, solution,
-              PolyFillType.pftEvenOdd, PolyFillType.pftEvenOdd);
-      }
-      //------------------------------------------------------------------------------
-
-      internal bool Execute(ClipType clipType, PolyTree polytree)
-      {
-          return Execute(clipType, polytree,
-              PolyFillType.pftEvenOdd, PolyFillType.pftEvenOdd);
-      }
-      //------------------------------------------------------------------------------
-
-      internal void FixHoleLinkage(OutRec outRec)
-      {
-        //skip if an outermost polygon or
-        //already already points to the correct FirstLeft ...
-        if (outRec.FirstLeft == null ||
-              (outRec.IsHole != outRec.FirstLeft.IsHole &&
-              outRec.FirstLeft.Pts != null)) return;
-
-        OutRec orfl = outRec.FirstLeft;
-        while (orfl != null && ((orfl.IsHole == outRec.IsHole) || orfl.Pts == null))
-          orfl = orfl.FirstLeft;
-        outRec.FirstLeft = orfl;
-      }
-      //------------------------------------------------------------------------------
-
-      private bool ExecuteInternal()
-      {
-        try
+        internal bool StrictlySimple
         {
-          Reset();
-          if (MCurrentLm == null) return false;
-
-          cInt botY = PopScanbeam();
-          do
-          {
-            InsertLocalMinimaIntoAEL(botY);
-            m_GhostJoins.Clear();
-            ProcessHorizontals(false);
-            if (m_Scanbeam == null) break;
-            cInt topY = PopScanbeam();
-            if (!ProcessIntersections(topY)) return false;
-            ProcessEdgesAtTopOfScanbeam(topY);
-            botY = topY;
-          } while (m_Scanbeam != null || MCurrentLm != null);
-
-          //fix orientations ...
-          for (int i = 0; i < m_PolyOuts.Count; i++)
-          {
-            OutRec outRec = m_PolyOuts[i];
-            if (outRec.Pts == null || outRec.IsOpen) continue;
-            if ((outRec.IsHole ^ ReverseSolution) == (Area(outRec) > 0))
-              ReversePolyPtLinks(outRec.Pts);
-          }
-
-          JoinCommonEdges();
-
-          for (int i = 0; i < m_PolyOuts.Count; i++)
-          {
-            OutRec outRec = m_PolyOuts[i];
-            if (outRec.Pts != null && !outRec.IsOpen) 
-              FixupOutPolygon(outRec);
-          }
-
-          if (StrictlySimple) DoSimplePolygons();
-          return true;
+            get;
+            set;
         }
-        //catch { return false; }
-        finally 
+        //------------------------------------------------------------------------------
+
+        private void InsertScanbeam(cInt Y)
         {
-          m_Joins.Clear();
-          m_GhostJoins.Clear();          
+            if (m_Scanbeam == null)
+            {
+                m_Scanbeam = new Scanbeam();
+                m_Scanbeam.Next = null;
+                m_Scanbeam.Y = Y;
+            }
+            else if (Y > m_Scanbeam.Y)
+            {
+                Scanbeam newSb = new Scanbeam();
+                newSb.Y = Y;
+                newSb.Next = m_Scanbeam;
+                m_Scanbeam = newSb;
+            }
+            else
+            {
+                Scanbeam sb2 = m_Scanbeam;
+                while (sb2.Next != null && (Y <= sb2.Next.Y)) sb2 = sb2.Next;
+                if (Y == sb2.Y) return; //ie ignores duplicates
+                Scanbeam newSb = new Scanbeam();
+                newSb.Y = Y;
+                newSb.Next = sb2.Next;
+                sb2.Next = newSb;
+            }
         }
-      }
-      //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-      private cInt PopScanbeam()
-      {
-        cInt Y = m_Scanbeam.Y;
-        m_Scanbeam = m_Scanbeam.Next;
-        return Y;
-      }
-      //------------------------------------------------------------------------------
+        internal bool Execute(ClipType clipType, Paths solution,
+            PolyFillType subjFillType, PolyFillType clipFillType)
+        {
+            if (m_ExecuteLocked) return false;
+            if (MHasOpenPaths) throw
+              new ClipperException("Error: PolyTree struct is need for open path clipping.");
 
-      private void DisposeAllPolyPts(){
-        for (int i = 0; i < m_PolyOuts.Count; ++i) DisposeOutRec(i);
-        m_PolyOuts.Clear();
-      }
-      //------------------------------------------------------------------------------
+            m_ExecuteLocked = true;
+            solution.Clear();
+            m_SubjFillType = subjFillType;
+            m_ClipFillType = clipFillType;
+            m_ClipType = clipType;
+            m_UsingPolyTree = false;
+            bool succeeded;
+            try
+            {
+                succeeded = ExecuteInternal();
+                //build the return polygons ...
+                if (succeeded) BuildResult(solution);
+            }
+            finally
+            {
+                DisposeAllPolyPts();
+                m_ExecuteLocked = false;
+            }
+            return succeeded;
+        }
+        //------------------------------------------------------------------------------
 
-      void DisposeOutRec(int index)
-      {
-        OutRec outRec = m_PolyOuts[index];
-        outRec.Pts = null;
-        outRec = null;
-        m_PolyOuts[index] = null;
-      }
-      //------------------------------------------------------------------------------
+        internal bool Execute(ClipType clipType, PolyTree polytree,
+            PolyFillType subjFillType, PolyFillType clipFillType)
+        {
+            if (m_ExecuteLocked) return false;
+            m_ExecuteLocked = true;
+            m_SubjFillType = subjFillType;
+            m_ClipFillType = clipFillType;
+            m_ClipType = clipType;
+            m_UsingPolyTree = true;
+            bool succeeded;
+            try
+            {
+                succeeded = ExecuteInternal();
+                //build the return polygons ...
+                if (succeeded) BuildResult2(polytree);
+            }
+            finally
+            {
+                DisposeAllPolyPts();
+                m_ExecuteLocked = false;
+            }
+            return succeeded;
+        }
+        //------------------------------------------------------------------------------
 
-      private void AddJoin(OutPt Op1, OutPt Op2, IntPoint OffPt)
-      {
-        Join j = new Join();
-        j.OutPt1 = Op1;
-        j.OutPt2 = Op2;
-        j.OffPt = OffPt;
-        m_Joins.Add(j);
-      }
-      //------------------------------------------------------------------------------
+        internal bool Execute(ClipType clipType, Paths solution)
+        {
+            return Execute(clipType, solution,
+                PolyFillType.pftEvenOdd, PolyFillType.pftEvenOdd);
+        }
+        //------------------------------------------------------------------------------
 
-      private void AddGhostJoin(OutPt Op, IntPoint OffPt)
-      {
-        Join j = new Join();
-        j.OutPt1 = Op;
-        j.OffPt = OffPt;
-        m_GhostJoins.Add(j);
-      }
-      //------------------------------------------------------------------------------
+        internal bool Execute(ClipType clipType, PolyTree polytree)
+        {
+            return Execute(clipType, polytree,
+                PolyFillType.pftEvenOdd, PolyFillType.pftEvenOdd);
+        }
+        //------------------------------------------------------------------------------
+
+        internal void FixHoleLinkage(OutRec outRec)
+        {
+            //skip if an outermost polygon or
+            //already already points to the correct FirstLeft ...
+            if (outRec.FirstLeft == null ||
+                  (outRec.IsHole != outRec.FirstLeft.IsHole &&
+                  outRec.FirstLeft.Pts != null)) return;
+
+            OutRec orfl = outRec.FirstLeft;
+            while (orfl != null && ((orfl.IsHole == outRec.IsHole) || orfl.Pts == null))
+                orfl = orfl.FirstLeft;
+            outRec.FirstLeft = orfl;
+        }
+        //------------------------------------------------------------------------------
+
+        private bool ExecuteInternal()
+        {
+            try
+            {
+                Reset();
+                if (MCurrentLm == null) return false;
+
+                cInt botY = PopScanbeam();
+                do
+                {
+                    InsertLocalMinimaIntoAEL(botY);
+                    m_GhostJoins.Clear();
+                    ProcessHorizontals(false);
+                    if (m_Scanbeam == null) break;
+                    cInt topY = PopScanbeam();
+                    if (!ProcessIntersections(topY)) return false;
+                    ProcessEdgesAtTopOfScanbeam(topY);
+                    botY = topY;
+                } while (m_Scanbeam != null || MCurrentLm != null);
+
+                //fix orientations ...
+                for (int i = 0; i < m_PolyOuts.Count; i++)
+                {
+                    OutRec outRec = m_PolyOuts[i];
+                    if (outRec.Pts == null || outRec.IsOpen) continue;
+                    if ((outRec.IsHole ^ ReverseSolution) == (Area(outRec) > 0))
+                        ReversePolyPtLinks(outRec.Pts);
+                }
+
+                JoinCommonEdges();
+
+                for (int i = 0; i < m_PolyOuts.Count; i++)
+                {
+                    OutRec outRec = m_PolyOuts[i];
+                    if (outRec.Pts != null && !outRec.IsOpen)
+                        FixupOutPolygon(outRec);
+                }
+
+                if (StrictlySimple) DoSimplePolygons();
+                return true;
+            }
+            //catch { return false; }
+            finally
+            {
+                m_Joins.Clear();
+                m_GhostJoins.Clear();
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        private cInt PopScanbeam()
+        {
+            cInt Y = m_Scanbeam.Y;
+            m_Scanbeam = m_Scanbeam.Next;
+            return Y;
+        }
+        //------------------------------------------------------------------------------
+
+        private void DisposeAllPolyPts()
+        {
+            for (int i = 0; i < m_PolyOuts.Count; ++i) DisposeOutRec(i);
+            m_PolyOuts.Clear();
+        }
+        //------------------------------------------------------------------------------
+
+        void DisposeOutRec(int index)
+        {
+            OutRec outRec = m_PolyOuts[index];
+            outRec.Pts = null;
+            outRec = null;
+            m_PolyOuts[index] = null;
+        }
+        //------------------------------------------------------------------------------
+
+        private void AddJoin(OutPt Op1, OutPt Op2, IntPoint OffPt)
+        {
+            Join j = new Join();
+            j.OutPt1 = Op1;
+            j.OutPt2 = Op2;
+            j.OffPt = OffPt;
+            m_Joins.Add(j);
+        }
+        //------------------------------------------------------------------------------
+
+        private void AddGhostJoin(OutPt Op, IntPoint OffPt)
+        {
+            Join j = new Join();
+            j.OutPt1 = Op;
+            j.OffPt = OffPt;
+            m_GhostJoins.Add(j);
+        }
+        //------------------------------------------------------------------------------
 
 #if use_xyz
       internal void SetZ(ref IntPoint pt, TEdge e1, TEdge e2)
@@ -1514,228 +1519,194 @@ namespace TVGL.Boolean_Operations.Clipper
       //------------------------------------------------------------------------------
 #endif
 
-      private void InsertLocalMinimaIntoAEL(cInt botY)
-      {
-        while(  MCurrentLm != null  && ( MCurrentLm.Y == botY ) )
+        private void InsertLocalMinimaIntoAEL(cInt botY)
         {
-          TEdge lb = MCurrentLm.LeftBound;
-          TEdge rb = MCurrentLm.RightBound;
-          PopLocalMinima();
-
-          OutPt Op1 = null;
-          if (lb == null)
-          {
-            InsertEdgeIntoAEL(rb, null);
-            SetWindingCount(rb);
-            if (IsContributing(rb))
-              Op1 = AddOutPt(rb, rb.Bot);
-          }
-          else if (rb == null)
-          {
-            InsertEdgeIntoAEL(lb, null);
-            SetWindingCount(lb);
-            if (IsContributing(lb))
-              Op1 = AddOutPt(lb, lb.Bot);
-            InsertScanbeam(lb.Top.Y);
-          }
-          else
-          {
-            InsertEdgeIntoAEL(lb, null);
-            InsertEdgeIntoAEL(rb, lb);
-            SetWindingCount(lb);
-            rb.WindCnt = lb.WindCnt;
-            rb.WindCnt2 = lb.WindCnt2;
-            if (IsContributing(lb))
-              Op1 = AddLocalMinPoly(lb, rb, lb.Bot);
-            InsertScanbeam(lb.Top.Y);
-          }
-
-          if (rb != null)
-          {
-            if (IsHorizontal(rb))
-              AddEdgeToSEL(rb);
-            else
-              InsertScanbeam(rb.Top.Y);
-          }
-
-          if (lb == null || rb == null) continue;
-
-          //if output polygons share an Edge with a horizontal rb, they'll need joining later ...
-          if (Op1 != null && IsHorizontal(rb) && 
-            m_GhostJoins.Count > 0 && rb.WindDelta != 0)
-          {
-            for (int i = 0; i < m_GhostJoins.Count; i++)
+            while (MCurrentLm != null && (MCurrentLm.Y == botY))
             {
-              //if the horizontal Rb and a 'ghost' horizontal overlap, then convert
-              //the 'ghost' join to a real join ready for later ...
-              Join j = m_GhostJoins[i];
-              if (HorzSegmentsOverlap(j.OutPt1.Pt.X, j.OffPt.X, rb.Bot.X, rb.Top.X))
-                AddJoin(j.OutPt1, Op1, j.OffPt);
-            }
-          }
+                TEdge lb = MCurrentLm.LeftBound;
+                TEdge rb = MCurrentLm.RightBound;
+                PopLocalMinima();
 
-          if (lb.OutIdx >= 0 && lb.PrevInAEL != null &&
-            lb.PrevInAEL.Curr.X == lb.Bot.X &&
-            lb.PrevInAEL.OutIdx >= 0 &&
-            SlopesEqual(lb.PrevInAEL, lb, MUseFullRange) &&
-            lb.WindDelta != 0 && lb.PrevInAEL.WindDelta != 0)
-          {
-            OutPt Op2 = AddOutPt(lb.PrevInAEL, lb.Bot);
-            AddJoin(Op1, Op2, lb.Top);
-          }
-
-          if( lb.NextInAEL != rb )
-          {
-
-            if (rb.OutIdx >= 0 && rb.PrevInAEL.OutIdx >= 0 &&
-              SlopesEqual(rb.PrevInAEL, rb, MUseFullRange) &&
-              rb.WindDelta != 0 && rb.PrevInAEL.WindDelta != 0)
-            {
-              OutPt Op2 = AddOutPt(rb.PrevInAEL, rb.Bot);
-              AddJoin(Op1, Op2, rb.Top);
-            }
-
-            TEdge e = lb.NextInAEL;
-            if (e != null)
-              while (e != rb)
-              {
-                //nb: For calculating winding counts etc, IntersectEdges() assumes
-                //that param1 will be to the right of param2 ABOVE the intersection ...
-                IntersectEdges(rb, e, lb.Curr); //order important here
-                e = e.NextInAEL;
-              }
-          }
-        }
-      }
-      //------------------------------------------------------------------------------
-
-      private void InsertEdgeIntoAEL(TEdge edge, TEdge startEdge)
-      {
-        if (m_ActiveEdges == null)
-        {
-          edge.PrevInAEL = null;
-          edge.NextInAEL = null;
-          m_ActiveEdges = edge;
-        }
-        else if (startEdge == null && E2InsertsBeforeE1(m_ActiveEdges, edge))
-        {
-          edge.PrevInAEL = null;
-          edge.NextInAEL = m_ActiveEdges;
-          m_ActiveEdges.PrevInAEL = edge;
-          m_ActiveEdges = edge;
-        }
-        else
-        {
-          if (startEdge == null) startEdge = m_ActiveEdges;
-          while (startEdge.NextInAEL != null &&
-            !E2InsertsBeforeE1(startEdge.NextInAEL, edge))
-            startEdge = startEdge.NextInAEL;
-          edge.NextInAEL = startEdge.NextInAEL;
-          if (startEdge.NextInAEL != null) startEdge.NextInAEL.PrevInAEL = edge;
-          edge.PrevInAEL = startEdge;
-          startEdge.NextInAEL = edge;
-        }
-      }
-      //----------------------------------------------------------------------
-
-      private bool E2InsertsBeforeE1(TEdge e1, TEdge e2)
-      {
-          if (e2.Curr.X == e1.Curr.X)
-          {
-              if (e2.Top.Y > e1.Top.Y)
-                  return e2.Top.X < TopX(e1, e2.Top.Y);
-              else return e1.Top.X > TopX(e2, e1.Top.Y);
-          }
-          else return e2.Curr.X < e1.Curr.X;
-      }
-      //------------------------------------------------------------------------------
-
-      private bool IsEvenOddFillType(TEdge edge) 
-      {
-        if (edge.PolyTyp == PolyType.ptSubject)
-            return m_SubjFillType == PolyFillType.pftEvenOdd; 
-        else
-            return m_ClipFillType == PolyFillType.pftEvenOdd;
-      }
-      //------------------------------------------------------------------------------
-
-      private bool IsEvenOddAltFillType(TEdge edge) 
-      {
-        if (edge.PolyTyp == PolyType.ptSubject)
-            return m_ClipFillType == PolyFillType.pftEvenOdd; 
-        else
-            return m_SubjFillType == PolyFillType.pftEvenOdd;
-      }
-      //------------------------------------------------------------------------------
-
-      private bool IsContributing(TEdge edge)
-      {
-          PolyFillType pft, pft2;
-          if (edge.PolyTyp == PolyType.ptSubject)
-          {
-              pft = m_SubjFillType;
-              pft2 = m_ClipFillType;
-          }
-          else
-          {
-              pft = m_ClipFillType;
-              pft2 = m_SubjFillType;
-          }
-
-          switch (pft)
-          {
-              case PolyFillType.pftEvenOdd:
-                  //return false if a subj line has been flagged as inside a subj polygon
-                  if (edge.WindDelta == 0 && edge.WindCnt != 1) return false;
-                  break;
-              case PolyFillType.pftNonZero:
-                  if (Math.Abs(edge.WindCnt) != 1) return false;
-                  break;
-              case PolyFillType.pftPositive:
-                  if (edge.WindCnt != 1) return false;
-                  break;
-              default: //PolyFillType.pftNegative
-                  if (edge.WindCnt != -1) return false; 
-                  break;
-          }
-
-          switch (m_ClipType)
-          {
-            case ClipType.ctIntersection:
-                switch (pft2)
+                OutPt Op1 = null;
+                if (lb == null)
                 {
-                    case PolyFillType.pftEvenOdd:
-                    case PolyFillType.pftNonZero:
-                        return (edge.WindCnt2 != 0);
-                    case PolyFillType.pftPositive:
-                        return (edge.WindCnt2 > 0);
-                    default:
-                        return (edge.WindCnt2 < 0);
+                    InsertEdgeIntoAEL(rb, null);
+                    SetWindingCount(rb);
+                    if (IsContributing(rb))
+                        Op1 = AddOutPt(rb, rb.Bot);
                 }
-            case ClipType.ctUnion:
-                switch (pft2)
+                else if (rb == null)
                 {
-                    case PolyFillType.pftEvenOdd:
-                    case PolyFillType.pftNonZero:
-                        return (edge.WindCnt2 == 0);
-                    case PolyFillType.pftPositive:
-                        return (edge.WindCnt2 <= 0);
-                    default:
-                        return (edge.WindCnt2 >= 0);
+                    InsertEdgeIntoAEL(lb, null);
+                    SetWindingCount(lb);
+                    if (IsContributing(lb))
+                        Op1 = AddOutPt(lb, lb.Bot);
+                    InsertScanbeam(lb.Top.Y);
                 }
-            case ClipType.ctDifference:
-                if (edge.PolyTyp == PolyType.ptSubject)
-                    switch (pft2)
-                    {
-                        case PolyFillType.pftEvenOdd:
-                        case PolyFillType.pftNonZero:
-                            return (edge.WindCnt2 == 0);
-                        case PolyFillType.pftPositive:
-                            return (edge.WindCnt2 <= 0);
-                        default:
-                            return (edge.WindCnt2 >= 0);
-                    }
                 else
+                {
+                    InsertEdgeIntoAEL(lb, null);
+                    InsertEdgeIntoAEL(rb, lb);
+                    SetWindingCount(lb);
+                    rb.WindCnt = lb.WindCnt;
+                    rb.WindCnt2 = lb.WindCnt2;
+                    if (IsContributing(lb))
+                        Op1 = AddLocalMinPoly(lb, rb, lb.Bot);
+                    InsertScanbeam(lb.Top.Y);
+                }
+
+                if (rb != null)
+                {
+                    if (IsHorizontal(rb))
+                        AddEdgeToSEL(rb);
+                    else
+                        InsertScanbeam(rb.Top.Y);
+                }
+
+                if (lb == null || rb == null) continue;
+
+                //if output polygons share an Edge with a horizontal rb, they'll need joining later ...
+                if (Op1 != null && IsHorizontal(rb) &&
+                  m_GhostJoins.Count > 0 && rb.WindDelta != 0)
+                {
+                    for (int i = 0; i < m_GhostJoins.Count; i++)
+                    {
+                        //if the horizontal Rb and a 'ghost' horizontal overlap, then convert
+                        //the 'ghost' join to a real join ready for later ...
+                        Join j = m_GhostJoins[i];
+                        if (HorzSegmentsOverlap(j.OutPt1.Pt.X, j.OffPt.X, rb.Bot.X, rb.Top.X))
+                            AddJoin(j.OutPt1, Op1, j.OffPt);
+                    }
+                }
+
+                if (lb.OutIdx >= 0 && lb.PrevInAEL != null &&
+                  lb.PrevInAEL.Curr.X == lb.Bot.X &&
+                  lb.PrevInAEL.OutIdx >= 0 &&
+                  SlopesEqual(lb.PrevInAEL, lb, MUseFullRange) &&
+                  lb.WindDelta != 0 && lb.PrevInAEL.WindDelta != 0)
+                {
+                    OutPt Op2 = AddOutPt(lb.PrevInAEL, lb.Bot);
+                    AddJoin(Op1, Op2, lb.Top);
+                }
+
+                if (lb.NextInAEL != rb)
+                {
+
+                    if (rb.OutIdx >= 0 && rb.PrevInAEL.OutIdx >= 0 &&
+                      SlopesEqual(rb.PrevInAEL, rb, MUseFullRange) &&
+                      rb.WindDelta != 0 && rb.PrevInAEL.WindDelta != 0)
+                    {
+                        OutPt Op2 = AddOutPt(rb.PrevInAEL, rb.Bot);
+                        AddJoin(Op1, Op2, rb.Top);
+                    }
+
+                    TEdge e = lb.NextInAEL;
+                    if (e != null)
+                        while (e != rb)
+                        {
+                            //nb: For calculating winding counts etc, IntersectEdges() assumes
+                            //that param1 will be to the right of param2 ABOVE the intersection ...
+                            IntersectEdges(rb, e, lb.Curr); //order important here
+                            e = e.NextInAEL;
+                        }
+                }
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        private void InsertEdgeIntoAEL(TEdge edge, TEdge startEdge)
+        {
+            if (m_ActiveEdges == null)
+            {
+                edge.PrevInAEL = null;
+                edge.NextInAEL = null;
+                m_ActiveEdges = edge;
+            }
+            else if (startEdge == null && E2InsertsBeforeE1(m_ActiveEdges, edge))
+            {
+                edge.PrevInAEL = null;
+                edge.NextInAEL = m_ActiveEdges;
+                m_ActiveEdges.PrevInAEL = edge;
+                m_ActiveEdges = edge;
+            }
+            else
+            {
+                if (startEdge == null) startEdge = m_ActiveEdges;
+                while (startEdge.NextInAEL != null &&
+                  !E2InsertsBeforeE1(startEdge.NextInAEL, edge))
+                    startEdge = startEdge.NextInAEL;
+                edge.NextInAEL = startEdge.NextInAEL;
+                if (startEdge.NextInAEL != null) startEdge.NextInAEL.PrevInAEL = edge;
+                edge.PrevInAEL = startEdge;
+                startEdge.NextInAEL = edge;
+            }
+        }
+        //----------------------------------------------------------------------
+
+        private bool E2InsertsBeforeE1(TEdge e1, TEdge e2)
+        {
+            if (e2.Curr.X == e1.Curr.X)
+            {
+                if (e2.Top.Y > e1.Top.Y)
+                    return e2.Top.X < TopX(e1, e2.Top.Y);
+                else return e1.Top.X > TopX(e2, e1.Top.Y);
+            }
+            else return e2.Curr.X < e1.Curr.X;
+        }
+        //------------------------------------------------------------------------------
+
+        private bool IsEvenOddFillType(TEdge edge)
+        {
+            if (edge.PolyTyp == PolyType.ptSubject)
+                return m_SubjFillType == PolyFillType.pftEvenOdd;
+            else
+                return m_ClipFillType == PolyFillType.pftEvenOdd;
+        }
+        //------------------------------------------------------------------------------
+
+        private bool IsEvenOddAltFillType(TEdge edge)
+        {
+            if (edge.PolyTyp == PolyType.ptSubject)
+                return m_ClipFillType == PolyFillType.pftEvenOdd;
+            else
+                return m_SubjFillType == PolyFillType.pftEvenOdd;
+        }
+        //------------------------------------------------------------------------------
+
+        private bool IsContributing(TEdge edge)
+        {
+            PolyFillType pft, pft2;
+            if (edge.PolyTyp == PolyType.ptSubject)
+            {
+                pft = m_SubjFillType;
+                pft2 = m_ClipFillType;
+            }
+            else
+            {
+                pft = m_ClipFillType;
+                pft2 = m_SubjFillType;
+            }
+
+            switch (pft)
+            {
+                case PolyFillType.pftEvenOdd:
+                    //return false if a subj line has been flagged as inside a subj polygon
+                    if (edge.WindDelta == 0 && edge.WindCnt != 1) return false;
+                    break;
+                case PolyFillType.pftNonZero:
+                    if (Math.Abs(edge.WindCnt) != 1) return false;
+                    break;
+                case PolyFillType.pftPositive:
+                    if (edge.WindCnt != 1) return false;
+                    break;
+                default: //PolyFillType.pftNegative
+                    if (edge.WindCnt != -1) return false;
+                    break;
+            }
+
+            switch (m_ClipType)
+            {
+                case ClipType.ctIntersection:
                     switch (pft2)
                     {
                         case PolyFillType.pftEvenOdd:
@@ -1746,657 +1717,696 @@ namespace TVGL.Boolean_Operations.Clipper
                         default:
                             return (edge.WindCnt2 < 0);
                     }
-            case ClipType.ctXor:
-                if (edge.WindDelta == 0) //XOr always contributing unless open
-                  switch (pft2)
-                  {
-                    case PolyFillType.pftEvenOdd:
-                    case PolyFillType.pftNonZero:
-                      return (edge.WindCnt2 == 0);
-                    case PolyFillType.pftPositive:
-                      return (edge.WindCnt2 <= 0);
-                    default:
-                      return (edge.WindCnt2 >= 0);
-                  }
-                else
-                  return true;
-          }
-          return true;
-      }
-      //------------------------------------------------------------------------------
+                case ClipType.ctUnion:
+                    switch (pft2)
+                    {
+                        case PolyFillType.pftEvenOdd:
+                        case PolyFillType.pftNonZero:
+                            return (edge.WindCnt2 == 0);
+                        case PolyFillType.pftPositive:
+                            return (edge.WindCnt2 <= 0);
+                        default:
+                            return (edge.WindCnt2 >= 0);
+                    }
+                case ClipType.ctDifference:
+                    if (edge.PolyTyp == PolyType.ptSubject)
+                        switch (pft2)
+                        {
+                            case PolyFillType.pftEvenOdd:
+                            case PolyFillType.pftNonZero:
+                                return (edge.WindCnt2 == 0);
+                            case PolyFillType.pftPositive:
+                                return (edge.WindCnt2 <= 0);
+                            default:
+                                return (edge.WindCnt2 >= 0);
+                        }
+                    else
+                        switch (pft2)
+                        {
+                            case PolyFillType.pftEvenOdd:
+                            case PolyFillType.pftNonZero:
+                                return (edge.WindCnt2 != 0);
+                            case PolyFillType.pftPositive:
+                                return (edge.WindCnt2 > 0);
+                            default:
+                                return (edge.WindCnt2 < 0);
+                        }
+                case ClipType.ctXor:
+                    if (edge.WindDelta == 0) //XOr always contributing unless open
+                        switch (pft2)
+                        {
+                            case PolyFillType.pftEvenOdd:
+                            case PolyFillType.pftNonZero:
+                                return (edge.WindCnt2 == 0);
+                            case PolyFillType.pftPositive:
+                                return (edge.WindCnt2 <= 0);
+                            default:
+                                return (edge.WindCnt2 >= 0);
+                        }
+                    else
+                        return true;
+            }
+            return true;
+        }
+        //------------------------------------------------------------------------------
 
-      private void SetWindingCount(TEdge edge)
-      {
-        TEdge e = edge.PrevInAEL;
-        //find the edge of the same polytype that immediately preceeds 'edge' in AEL
-        while (e != null && ((e.PolyTyp != edge.PolyTyp) || (e.WindDelta == 0))) e = e.PrevInAEL;
-        if (e == null)
+        private void SetWindingCount(TEdge edge)
         {
-          edge.WindCnt = (edge.WindDelta == 0 ? 1 : edge.WindDelta);
-          edge.WindCnt2 = 0;
-          e = m_ActiveEdges; //ie get ready to calc WindCnt2
+            TEdge e = edge.PrevInAEL;
+            //find the edge of the same polytype that immediately preceeds 'edge' in AEL
+            while (e != null && ((e.PolyTyp != edge.PolyTyp) || (e.WindDelta == 0))) e = e.PrevInAEL;
+            if (e == null)
+            {
+                edge.WindCnt = (edge.WindDelta == 0 ? 1 : edge.WindDelta);
+                edge.WindCnt2 = 0;
+                e = m_ActiveEdges; //ie get ready to calc WindCnt2
+            }
+            else if (edge.WindDelta == 0 && m_ClipType != ClipType.ctUnion)
+            {
+                edge.WindCnt = 1;
+                edge.WindCnt2 = e.WindCnt2;
+                e = e.NextInAEL; //ie get ready to calc WindCnt2
+            }
+            else if (IsEvenOddFillType(edge))
+            {
+                //EvenOdd filling ...
+                if (edge.WindDelta == 0)
+                {
+                    //are we inside a subj polygon ...
+                    bool Inside = true;
+                    TEdge e2 = e.PrevInAEL;
+                    while (e2 != null)
+                    {
+                        if (e2.PolyTyp == e.PolyTyp && e2.WindDelta != 0)
+                            Inside = !Inside;
+                        e2 = e2.PrevInAEL;
+                    }
+                    edge.WindCnt = (Inside ? 0 : 1);
+                }
+                else
+                {
+                    edge.WindCnt = edge.WindDelta;
+                }
+                edge.WindCnt2 = e.WindCnt2;
+                e = e.NextInAEL; //ie get ready to calc WindCnt2
+            }
+            else
+            {
+                //nonZero, Positive or Negative filling ...
+                if (e.WindCnt * e.WindDelta < 0)
+                {
+                    //prev edge is 'decreasing' WindCount (WC) toward zero
+                    //so we're outside the previous polygon ...
+                    if (Math.Abs(e.WindCnt) > 1)
+                    {
+                        //outside prev poly but still inside another.
+                        //when reversing direction of prev poly use the same WC 
+                        if (e.WindDelta * edge.WindDelta < 0) edge.WindCnt = e.WindCnt;
+                        //otherwise continue to 'decrease' WC ...
+                        else edge.WindCnt = e.WindCnt + edge.WindDelta;
+                    }
+                    else
+                        //now outside all polys of same polytype so set own WC ...
+                        edge.WindCnt = (edge.WindDelta == 0 ? 1 : edge.WindDelta);
+                }
+                else
+                {
+                    //prev edge is 'increasing' WindCount (WC) away from zero
+                    //so we're inside the previous polygon ...
+                    if (edge.WindDelta == 0)
+                        edge.WindCnt = (e.WindCnt < 0 ? e.WindCnt - 1 : e.WindCnt + 1);
+                    //if wind direction is reversing prev then use same WC
+                    else if (e.WindDelta * edge.WindDelta < 0)
+                        edge.WindCnt = e.WindCnt;
+                    //otherwise add to WC ...
+                    else edge.WindCnt = e.WindCnt + edge.WindDelta;
+                }
+                edge.WindCnt2 = e.WindCnt2;
+                e = e.NextInAEL; //ie get ready to calc WindCnt2
+            }
+
+            //update WindCnt2 ...
+            if (IsEvenOddAltFillType(edge))
+            {
+                //EvenOdd filling ...
+                while (e != edge)
+                {
+                    if (e.WindDelta != 0)
+                        edge.WindCnt2 = (edge.WindCnt2 == 0 ? 1 : 0);
+                    e = e.NextInAEL;
+                }
+            }
+            else
+            {
+                //nonZero, Positive or Negative filling ...
+                while (e != edge)
+                {
+                    edge.WindCnt2 += e.WindDelta;
+                    e = e.NextInAEL;
+                }
+            }
         }
-        else if (edge.WindDelta == 0 && m_ClipType != ClipType.ctUnion)
+        //------------------------------------------------------------------------------
+
+        private void AddEdgeToSEL(TEdge edge)
         {
-          edge.WindCnt = 1;
-          edge.WindCnt2 = e.WindCnt2;
-          e = e.NextInAEL; //ie get ready to calc WindCnt2
+            //SEL pointers in PEdge are reused to build a list of horizontal edges.
+            //However, we don't need to worry about order with horizontal edge processing.
+            if (m_SortedEdges == null)
+            {
+                m_SortedEdges = edge;
+                edge.PrevInSEL = null;
+                edge.NextInSEL = null;
+            }
+            else
+            {
+                edge.NextInSEL = m_SortedEdges;
+                edge.PrevInSEL = null;
+                m_SortedEdges.PrevInSEL = edge;
+                m_SortedEdges = edge;
+            }
         }
-        else if (IsEvenOddFillType(edge))
+        //------------------------------------------------------------------------------
+
+        private void CopyAELToSEL()
         {
-          //EvenOdd filling ...
-          if (edge.WindDelta == 0)
-          {
-            //are we inside a subj polygon ...
-            bool Inside = true;
+            TEdge e = m_ActiveEdges;
+            m_SortedEdges = e;
+            while (e != null)
+            {
+                e.PrevInSEL = e.PrevInAEL;
+                e.NextInSEL = e.NextInAEL;
+                e = e.NextInAEL;
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        private void SwapPositionsInAEL(TEdge edge1, TEdge edge2)
+        {
+            //check that one or other edge hasn't already been removed from AEL ...
+            if (edge1.NextInAEL == edge1.PrevInAEL ||
+              edge2.NextInAEL == edge2.PrevInAEL) return;
+
+            if (edge1.NextInAEL == edge2)
+            {
+                TEdge next = edge2.NextInAEL;
+                if (next != null)
+                    next.PrevInAEL = edge1;
+                TEdge prev = edge1.PrevInAEL;
+                if (prev != null)
+                    prev.NextInAEL = edge2;
+                edge2.PrevInAEL = prev;
+                edge2.NextInAEL = edge1;
+                edge1.PrevInAEL = edge2;
+                edge1.NextInAEL = next;
+            }
+            else if (edge2.NextInAEL == edge1)
+            {
+                TEdge next = edge1.NextInAEL;
+                if (next != null)
+                    next.PrevInAEL = edge2;
+                TEdge prev = edge2.PrevInAEL;
+                if (prev != null)
+                    prev.NextInAEL = edge1;
+                edge1.PrevInAEL = prev;
+                edge1.NextInAEL = edge2;
+                edge2.PrevInAEL = edge1;
+                edge2.NextInAEL = next;
+            }
+            else
+            {
+                TEdge next = edge1.NextInAEL;
+                TEdge prev = edge1.PrevInAEL;
+                edge1.NextInAEL = edge2.NextInAEL;
+                if (edge1.NextInAEL != null)
+                    edge1.NextInAEL.PrevInAEL = edge1;
+                edge1.PrevInAEL = edge2.PrevInAEL;
+                if (edge1.PrevInAEL != null)
+                    edge1.PrevInAEL.NextInAEL = edge1;
+                edge2.NextInAEL = next;
+                if (edge2.NextInAEL != null)
+                    edge2.NextInAEL.PrevInAEL = edge2;
+                edge2.PrevInAEL = prev;
+                if (edge2.PrevInAEL != null)
+                    edge2.PrevInAEL.NextInAEL = edge2;
+            }
+
+            if (edge1.PrevInAEL == null)
+                m_ActiveEdges = edge1;
+            else if (edge2.PrevInAEL == null)
+                m_ActiveEdges = edge2;
+        }
+        //------------------------------------------------------------------------------
+
+        private void SwapPositionsInSEL(TEdge edge1, TEdge edge2)
+        {
+            if (edge1.NextInSEL == null && edge1.PrevInSEL == null)
+                return;
+            if (edge2.NextInSEL == null && edge2.PrevInSEL == null)
+                return;
+
+            if (edge1.NextInSEL == edge2)
+            {
+                TEdge next = edge2.NextInSEL;
+                if (next != null)
+                    next.PrevInSEL = edge1;
+                TEdge prev = edge1.PrevInSEL;
+                if (prev != null)
+                    prev.NextInSEL = edge2;
+                edge2.PrevInSEL = prev;
+                edge2.NextInSEL = edge1;
+                edge1.PrevInSEL = edge2;
+                edge1.NextInSEL = next;
+            }
+            else if (edge2.NextInSEL == edge1)
+            {
+                TEdge next = edge1.NextInSEL;
+                if (next != null)
+                    next.PrevInSEL = edge2;
+                TEdge prev = edge2.PrevInSEL;
+                if (prev != null)
+                    prev.NextInSEL = edge1;
+                edge1.PrevInSEL = prev;
+                edge1.NextInSEL = edge2;
+                edge2.PrevInSEL = edge1;
+                edge2.NextInSEL = next;
+            }
+            else
+            {
+                TEdge next = edge1.NextInSEL;
+                TEdge prev = edge1.PrevInSEL;
+                edge1.NextInSEL = edge2.NextInSEL;
+                if (edge1.NextInSEL != null)
+                    edge1.NextInSEL.PrevInSEL = edge1;
+                edge1.PrevInSEL = edge2.PrevInSEL;
+                if (edge1.PrevInSEL != null)
+                    edge1.PrevInSEL.NextInSEL = edge1;
+                edge2.NextInSEL = next;
+                if (edge2.NextInSEL != null)
+                    edge2.NextInSEL.PrevInSEL = edge2;
+                edge2.PrevInSEL = prev;
+                if (edge2.PrevInSEL != null)
+                    edge2.PrevInSEL.NextInSEL = edge2;
+            }
+
+            if (edge1.PrevInSEL == null)
+                m_SortedEdges = edge1;
+            else if (edge2.PrevInSEL == null)
+                m_SortedEdges = edge2;
+        }
+        //------------------------------------------------------------------------------
+
+
+        private void AddLocalMaxPoly(TEdge e1, TEdge e2, IntPoint pt)
+        {
+            AddOutPt(e1, pt);
+            if (e2.WindDelta == 0) AddOutPt(e2, pt);
+            if (e1.OutIdx == e2.OutIdx)
+            {
+                e1.OutIdx = Unassigned;
+                e2.OutIdx = Unassigned;
+            }
+            else if (e1.OutIdx < e2.OutIdx)
+                AppendPolygon(e1, e2);
+            else
+                AppendPolygon(e2, e1);
+        }
+        //------------------------------------------------------------------------------
+
+        private OutPt AddLocalMinPoly(TEdge e1, TEdge e2, IntPoint pt)
+        {
+            OutPt result;
+            TEdge e, prevE;
+            if (IsHorizontal(e2) || (e1.Dx > e2.Dx))
+            {
+                result = AddOutPt(e1, pt);
+                e2.OutIdx = e1.OutIdx;
+                e1.Side = EdgeSide.esLeft;
+                e2.Side = EdgeSide.esRight;
+                e = e1;
+                if (e.PrevInAEL == e2)
+                    prevE = e2.PrevInAEL;
+                else
+                    prevE = e.PrevInAEL;
+            }
+            else
+            {
+                result = AddOutPt(e2, pt);
+                e1.OutIdx = e2.OutIdx;
+                e1.Side = EdgeSide.esRight;
+                e2.Side = EdgeSide.esLeft;
+                e = e2;
+                if (e.PrevInAEL == e1)
+                    prevE = e1.PrevInAEL;
+                else
+                    prevE = e.PrevInAEL;
+            }
+
+            if (prevE != null && prevE.OutIdx >= 0 &&
+                (TopX(prevE, pt.Y) == TopX(e, pt.Y)) &&
+                SlopesEqual(e, prevE, MUseFullRange) &&
+                (e.WindDelta != 0) && (prevE.WindDelta != 0))
+            {
+                OutPt outPt = AddOutPt(prevE, pt);
+                AddJoin(result, outPt, e.Top);
+            }
+            return result;
+        }
+        //------------------------------------------------------------------------------
+
+        private OutRec CreateOutRec()
+        {
+            OutRec result = new OutRec();
+            result.Idx = Unassigned;
+            result.IsHole = false;
+            result.IsOpen = false;
+            result.FirstLeft = null;
+            result.Pts = null;
+            result.BottomPt = null;
+            result.PolyNode = null;
+            m_PolyOuts.Add(result);
+            result.Idx = m_PolyOuts.Count - 1;
+            return result;
+        }
+        //------------------------------------------------------------------------------
+
+        private OutPt AddOutPt(TEdge e, IntPoint pt)
+        {
+            bool ToFront = (e.Side == EdgeSide.esLeft);
+            if (e.OutIdx < 0)
+            {
+                OutRec outRec = CreateOutRec();
+                outRec.IsOpen = (e.WindDelta == 0);
+                OutPt newOp = new OutPt();
+                outRec.Pts = newOp;
+                newOp.Idx = outRec.Idx;
+                newOp.Pt = pt;
+                newOp.Next = newOp;
+                newOp.Prev = newOp;
+                if (!outRec.IsOpen)
+                    SetHoleState(e, outRec);
+                e.OutIdx = outRec.Idx; //nb: do this after SetZ !
+                return newOp;
+            }
+            else
+            {
+                OutRec outRec = m_PolyOuts[e.OutIdx];
+                //OutRec.Pts is the 'Left-most' point & OutRec.Pts.Prev is the 'Right-most'
+                OutPt op = outRec.Pts;
+                if (ToFront && pt == op.Pt) return op;
+                else if (!ToFront && pt == op.Prev.Pt) return op.Prev;
+
+                OutPt newOp = new OutPt();
+                newOp.Idx = outRec.Idx;
+                newOp.Pt = pt;
+                newOp.Next = op;
+                newOp.Prev = op.Prev;
+                newOp.Prev.Next = newOp;
+                op.Prev = newOp;
+                if (ToFront) outRec.Pts = newOp;
+                return newOp;
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        internal void SwapPoints(ref IntPoint pt1, ref IntPoint pt2)
+        {
+            IntPoint tmp = new IntPoint(pt1);
+            pt1 = pt2;
+            pt2 = tmp;
+        }
+        //------------------------------------------------------------------------------
+
+        private bool HorzSegmentsOverlap(cInt seg1a, cInt seg1b, cInt seg2a, cInt seg2b)
+        {
+            if (seg1a > seg1b) Swap(ref seg1a, ref seg1b);
+            if (seg2a > seg2b) Swap(ref seg2a, ref seg2b);
+            return (seg1a < seg2b) && (seg2a < seg1b);
+        }
+        //------------------------------------------------------------------------------
+
+        private void SetHoleState(TEdge e, OutRec outRec)
+        {
+            bool isHole = false;
             TEdge e2 = e.PrevInAEL;
             while (e2 != null)
             {
-              if (e2.PolyTyp == e.PolyTyp && e2.WindDelta != 0)
-                Inside = !Inside;
-              e2 = e2.PrevInAEL;
+                if (e2.OutIdx >= 0 && e2.WindDelta != 0)
+                {
+                    isHole = !isHole;
+                    if (outRec.FirstLeft == null)
+                        outRec.FirstLeft = m_PolyOuts[e2.OutIdx];
+                }
+                e2 = e2.PrevInAEL;
             }
-            edge.WindCnt = (Inside ? 0 : 1);
-          }
-          else
-          {
-            edge.WindCnt = edge.WindDelta;
-          }
-          edge.WindCnt2 = e.WindCnt2;
-          e = e.NextInAEL; //ie get ready to calc WindCnt2
+            if (isHole)
+                outRec.IsHole = true;
         }
-        else
+        //------------------------------------------------------------------------------
+
+        private double GetDx(IntPoint pt1, IntPoint pt2)
         {
-          //nonZero, Positive or Negative filling ...
-          if (e.WindCnt * e.WindDelta < 0)
-          {
-            //prev edge is 'decreasing' WindCount (WC) toward zero
-            //so we're outside the previous polygon ...
-            if (Math.Abs(e.WindCnt) > 1)
+            if (pt1.Y == pt2.Y) return Horizontal;
+            else return (double)(pt2.X - pt1.X) / (pt2.Y - pt1.Y);
+        }
+        //---------------------------------------------------------------------------
+
+        private bool FirstIsBottomPt(OutPt btmPt1, OutPt btmPt2)
+        {
+            OutPt p = btmPt1.Prev;
+            while ((p.Pt == btmPt1.Pt) && (p != btmPt1)) p = p.Prev;
+            double dx1p = Math.Abs(GetDx(btmPt1.Pt, p.Pt));
+            p = btmPt1.Next;
+            while ((p.Pt == btmPt1.Pt) && (p != btmPt1)) p = p.Next;
+            double dx1n = Math.Abs(GetDx(btmPt1.Pt, p.Pt));
+
+            p = btmPt2.Prev;
+            while ((p.Pt == btmPt2.Pt) && (p != btmPt2)) p = p.Prev;
+            double dx2p = Math.Abs(GetDx(btmPt2.Pt, p.Pt));
+            p = btmPt2.Next;
+            while ((p.Pt == btmPt2.Pt) && (p != btmPt2)) p = p.Next;
+            double dx2n = Math.Abs(GetDx(btmPt2.Pt, p.Pt));
+            return (dx1p >= dx2p && dx1p >= dx2n) || (dx1n >= dx2p && dx1n >= dx2n);
+        }
+        //------------------------------------------------------------------------------
+
+        private OutPt GetBottomPt(OutPt pp)
+        {
+            OutPt dups = null;
+            OutPt p = pp.Next;
+            while (p != pp)
             {
-              //outside prev poly but still inside another.
-              //when reversing direction of prev poly use the same WC 
-              if (e.WindDelta * edge.WindDelta < 0) edge.WindCnt = e.WindCnt;
-              //otherwise continue to 'decrease' WC ...
-              else edge.WindCnt = e.WindCnt + edge.WindDelta;
+                if (p.Pt.Y > pp.Pt.Y)
+                {
+                    pp = p;
+                    dups = null;
+                }
+                else if (p.Pt.Y == pp.Pt.Y && p.Pt.X <= pp.Pt.X)
+                {
+                    if (p.Pt.X < pp.Pt.X)
+                    {
+                        dups = null;
+                        pp = p;
+                    }
+                    else
+                    {
+                        if (p.Next != pp && p.Prev != pp) dups = p;
+                    }
+                }
+                p = p.Next;
+            }
+            if (dups != null)
+            {
+                //there appears to be at least 2 vertices at bottomPt so ...
+                while (dups != p)
+                {
+                    if (!FirstIsBottomPt(p, dups)) pp = dups;
+                    dups = dups.Next;
+                    while (dups.Pt != pp.Pt) dups = dups.Next;
+                }
+            }
+            return pp;
+        }
+        //------------------------------------------------------------------------------
+
+        private OutRec GetLowermostRec(OutRec outRec1, OutRec outRec2)
+        {
+            //work out which polygon fragment has the correct hole state ...
+            if (outRec1.BottomPt == null)
+                outRec1.BottomPt = GetBottomPt(outRec1.Pts);
+            if (outRec2.BottomPt == null)
+                outRec2.BottomPt = GetBottomPt(outRec2.Pts);
+            OutPt bPt1 = outRec1.BottomPt;
+            OutPt bPt2 = outRec2.BottomPt;
+            if (bPt1.Pt.Y > bPt2.Pt.Y) return outRec1;
+            else if (bPt1.Pt.Y < bPt2.Pt.Y) return outRec2;
+            else if (bPt1.Pt.X < bPt2.Pt.X) return outRec1;
+            else if (bPt1.Pt.X > bPt2.Pt.X) return outRec2;
+            else if (bPt1.Next == bPt1) return outRec2;
+            else if (bPt2.Next == bPt2) return outRec1;
+            else if (FirstIsBottomPt(bPt1, bPt2)) return outRec1;
+            else return outRec2;
+        }
+        //------------------------------------------------------------------------------
+
+        bool Param1RightOfParam2(OutRec outRec1, OutRec outRec2)
+        {
+            do
+            {
+                outRec1 = outRec1.FirstLeft;
+                if (outRec1 == outRec2) return true;
+            } while (outRec1 != null);
+            return false;
+        }
+        //------------------------------------------------------------------------------
+
+        private OutRec GetOutRec(int idx)
+        {
+            OutRec outrec = m_PolyOuts[idx];
+            while (outrec != m_PolyOuts[outrec.Idx])
+                outrec = m_PolyOuts[outrec.Idx];
+            return outrec;
+        }
+        //------------------------------------------------------------------------------
+
+        private void AppendPolygon(TEdge e1, TEdge e2)
+        {
+            //get the start and ends of both output polygons ...
+            OutRec outRec1 = m_PolyOuts[e1.OutIdx];
+            OutRec outRec2 = m_PolyOuts[e2.OutIdx];
+
+            OutRec holeStateRec;
+            if (Param1RightOfParam2(outRec1, outRec2))
+                holeStateRec = outRec2;
+            else if (Param1RightOfParam2(outRec2, outRec1))
+                holeStateRec = outRec1;
+            else
+                holeStateRec = GetLowermostRec(outRec1, outRec2);
+
+            OutPt p1_lft = outRec1.Pts;
+            OutPt p1_rt = p1_lft.Prev;
+            OutPt p2_lft = outRec2.Pts;
+            OutPt p2_rt = p2_lft.Prev;
+
+            EdgeSide side;
+            //join e2 poly onto e1 poly and delete pointers to e2 ...
+            if (e1.Side == EdgeSide.esLeft)
+            {
+                if (e2.Side == EdgeSide.esLeft)
+                {
+                    //z y x a b c
+                    ReversePolyPtLinks(p2_lft);
+                    p2_lft.Next = p1_lft;
+                    p1_lft.Prev = p2_lft;
+                    p1_rt.Next = p2_rt;
+                    p2_rt.Prev = p1_rt;
+                    outRec1.Pts = p2_rt;
+                }
+                else
+                {
+                    //x y z a b c
+                    p2_rt.Next = p1_lft;
+                    p1_lft.Prev = p2_rt;
+                    p2_lft.Prev = p1_rt;
+                    p1_rt.Next = p2_lft;
+                    outRec1.Pts = p2_lft;
+                }
+                side = EdgeSide.esLeft;
             }
             else
-              //now outside all polys of same polytype so set own WC ...
-              edge.WindCnt = (edge.WindDelta == 0 ? 1 : edge.WindDelta);
-          }
-          else
-          {
-            //prev edge is 'increasing' WindCount (WC) away from zero
-            //so we're inside the previous polygon ...
-            if (edge.WindDelta == 0)
-              edge.WindCnt = (e.WindCnt < 0 ? e.WindCnt - 1 : e.WindCnt + 1);
-            //if wind direction is reversing prev then use same WC
-            else if (e.WindDelta * edge.WindDelta < 0)
-              edge.WindCnt = e.WindCnt;
-            //otherwise add to WC ...
-            else edge.WindCnt = e.WindCnt + edge.WindDelta;
-          }
-          edge.WindCnt2 = e.WindCnt2;
-          e = e.NextInAEL; //ie get ready to calc WindCnt2
-        }
-
-        //update WindCnt2 ...
-        if (IsEvenOddAltFillType(edge))
-        {
-          //EvenOdd filling ...
-          while (e != edge)
-          {
-            if (e.WindDelta != 0)
-              edge.WindCnt2 = (edge.WindCnt2 == 0 ? 1 : 0);
-            e = e.NextInAEL;
-          }
-        }
-        else
-        {
-          //nonZero, Positive or Negative filling ...
-          while (e != edge)
-          {
-            edge.WindCnt2 += e.WindDelta;
-            e = e.NextInAEL;
-          }
-        }
-      }
-      //------------------------------------------------------------------------------
-
-      private void AddEdgeToSEL(TEdge edge)
-      {
-          //SEL pointers in PEdge are reused to build a list of horizontal edges.
-          //However, we don't need to worry about order with horizontal edge processing.
-          if (m_SortedEdges == null)
-          {
-              m_SortedEdges = edge;
-              edge.PrevInSEL = null;
-              edge.NextInSEL = null;
-          }
-          else
-          {
-              edge.NextInSEL = m_SortedEdges;
-              edge.PrevInSEL = null;
-              m_SortedEdges.PrevInSEL = edge;
-              m_SortedEdges = edge;
-          }
-      }
-      //------------------------------------------------------------------------------
-
-      private void CopyAELToSEL()
-      {
-          TEdge e = m_ActiveEdges;
-          m_SortedEdges = e;
-          while (e != null)
-          {
-              e.PrevInSEL = e.PrevInAEL;
-              e.NextInSEL = e.NextInAEL;
-              e = e.NextInAEL;
-          }
-      }
-      //------------------------------------------------------------------------------
-
-      private void SwapPositionsInAEL(TEdge edge1, TEdge edge2)
-      {
-        //check that one or other edge hasn't already been removed from AEL ...
-          if (edge1.NextInAEL == edge1.PrevInAEL ||
-            edge2.NextInAEL == edge2.PrevInAEL) return;
-        
-          if (edge1.NextInAEL == edge2)
-          {
-              TEdge next = edge2.NextInAEL;
-              if (next != null)
-                  next.PrevInAEL = edge1;
-              TEdge prev = edge1.PrevInAEL;
-              if (prev != null)
-                  prev.NextInAEL = edge2;
-              edge2.PrevInAEL = prev;
-              edge2.NextInAEL = edge1;
-              edge1.PrevInAEL = edge2;
-              edge1.NextInAEL = next;
-          }
-          else if (edge2.NextInAEL == edge1)
-          {
-              TEdge next = edge1.NextInAEL;
-              if (next != null)
-                  next.PrevInAEL = edge2;
-              TEdge prev = edge2.PrevInAEL;
-              if (prev != null)
-                  prev.NextInAEL = edge1;
-              edge1.PrevInAEL = prev;
-              edge1.NextInAEL = edge2;
-              edge2.PrevInAEL = edge1;
-              edge2.NextInAEL = next;
-          }
-          else
-          {
-              TEdge next = edge1.NextInAEL;
-              TEdge prev = edge1.PrevInAEL;
-              edge1.NextInAEL = edge2.NextInAEL;
-              if (edge1.NextInAEL != null)
-                  edge1.NextInAEL.PrevInAEL = edge1;
-              edge1.PrevInAEL = edge2.PrevInAEL;
-              if (edge1.PrevInAEL != null)
-                  edge1.PrevInAEL.NextInAEL = edge1;
-              edge2.NextInAEL = next;
-              if (edge2.NextInAEL != null)
-                  edge2.NextInAEL.PrevInAEL = edge2;
-              edge2.PrevInAEL = prev;
-              if (edge2.PrevInAEL != null)
-                  edge2.PrevInAEL.NextInAEL = edge2;
-          }
-
-          if (edge1.PrevInAEL == null)
-              m_ActiveEdges = edge1;
-          else if (edge2.PrevInAEL == null)
-              m_ActiveEdges = edge2;
-      }
-      //------------------------------------------------------------------------------
-
-      private void SwapPositionsInSEL(TEdge edge1, TEdge edge2)
-      {
-          if (edge1.NextInSEL == null && edge1.PrevInSEL == null)
-              return;
-          if (edge2.NextInSEL == null && edge2.PrevInSEL == null)
-              return;
-
-          if (edge1.NextInSEL == edge2)
-          {
-              TEdge next = edge2.NextInSEL;
-              if (next != null)
-                  next.PrevInSEL = edge1;
-              TEdge prev = edge1.PrevInSEL;
-              if (prev != null)
-                  prev.NextInSEL = edge2;
-              edge2.PrevInSEL = prev;
-              edge2.NextInSEL = edge1;
-              edge1.PrevInSEL = edge2;
-              edge1.NextInSEL = next;
-          }
-          else if (edge2.NextInSEL == edge1)
-          {
-              TEdge next = edge1.NextInSEL;
-              if (next != null)
-                  next.PrevInSEL = edge2;
-              TEdge prev = edge2.PrevInSEL;
-              if (prev != null)
-                  prev.NextInSEL = edge1;
-              edge1.PrevInSEL = prev;
-              edge1.NextInSEL = edge2;
-              edge2.PrevInSEL = edge1;
-              edge2.NextInSEL = next;
-          }
-          else
-          {
-              TEdge next = edge1.NextInSEL;
-              TEdge prev = edge1.PrevInSEL;
-              edge1.NextInSEL = edge2.NextInSEL;
-              if (edge1.NextInSEL != null)
-                  edge1.NextInSEL.PrevInSEL = edge1;
-              edge1.PrevInSEL = edge2.PrevInSEL;
-              if (edge1.PrevInSEL != null)
-                  edge1.PrevInSEL.NextInSEL = edge1;
-              edge2.NextInSEL = next;
-              if (edge2.NextInSEL != null)
-                  edge2.NextInSEL.PrevInSEL = edge2;
-              edge2.PrevInSEL = prev;
-              if (edge2.PrevInSEL != null)
-                  edge2.PrevInSEL.NextInSEL = edge2;
-          }
-
-          if (edge1.PrevInSEL == null)
-              m_SortedEdges = edge1;
-          else if (edge2.PrevInSEL == null)
-              m_SortedEdges = edge2;
-      }
-      //------------------------------------------------------------------------------
-
-
-      private void AddLocalMaxPoly(TEdge e1, TEdge e2, IntPoint pt)
-      {
-          AddOutPt(e1, pt);
-          if (e2.WindDelta == 0) AddOutPt(e2, pt);
-          if (e1.OutIdx == e2.OutIdx)
-          {
-              e1.OutIdx = Unassigned;
-              e2.OutIdx = Unassigned;
-          }
-          else if (e1.OutIdx < e2.OutIdx) 
-              AppendPolygon(e1, e2);
-          else 
-              AppendPolygon(e2, e1);
-      }
-      //------------------------------------------------------------------------------
-
-      private OutPt AddLocalMinPoly(TEdge e1, TEdge e2, IntPoint pt)
-      {
-        OutPt result;
-        TEdge e, prevE;
-        if (IsHorizontal(e2) || (e1.Dx > e2.Dx))
-        {
-          result = AddOutPt(e1, pt);
-          e2.OutIdx = e1.OutIdx;
-          e1.Side = EdgeSide.esLeft;
-          e2.Side = EdgeSide.esRight;
-          e = e1;
-          if (e.PrevInAEL == e2)
-            prevE = e2.PrevInAEL; 
-          else
-            prevE = e.PrevInAEL;
-        }
-        else
-        {
-          result = AddOutPt(e2, pt);
-          e1.OutIdx = e2.OutIdx;
-          e1.Side = EdgeSide.esRight;
-          e2.Side = EdgeSide.esLeft;
-          e = e2;
-          if (e.PrevInAEL == e1)
-              prevE = e1.PrevInAEL;
-          else
-              prevE = e.PrevInAEL;
-        }
-
-        if (prevE != null && prevE.OutIdx >= 0 &&
-            (TopX(prevE, pt.Y) == TopX(e, pt.Y)) &&
-            SlopesEqual(e, prevE, MUseFullRange) &&
-            (e.WindDelta != 0) && (prevE.WindDelta != 0))
-        {
-          OutPt outPt = AddOutPt(prevE, pt);
-          AddJoin(result, outPt, e.Top);
-        }
-        return result;
-      }
-      //------------------------------------------------------------------------------
-
-      private OutRec CreateOutRec()
-      {
-        OutRec result = new OutRec();
-        result.Idx = Unassigned;
-        result.IsHole = false;
-        result.IsOpen = false;
-        result.FirstLeft = null;
-        result.Pts = null;
-        result.BottomPt = null;
-        result.PolyNode = null;
-        m_PolyOuts.Add(result);
-        result.Idx = m_PolyOuts.Count - 1;
-        return result;
-      }
-      //------------------------------------------------------------------------------
-
-      private OutPt AddOutPt(TEdge e, IntPoint pt)
-      {
-        bool ToFront = (e.Side == EdgeSide.esLeft);
-        if(  e.OutIdx < 0 )
-        {
-          OutRec outRec = CreateOutRec();
-          outRec.IsOpen = (e.WindDelta == 0);
-          OutPt newOp = new OutPt();
-          outRec.Pts = newOp;
-          newOp.Idx = outRec.Idx;
-          newOp.Pt = pt;
-          newOp.Next = newOp;
-          newOp.Prev = newOp;
-          if (!outRec.IsOpen)
-            SetHoleState(e, outRec);
-          e.OutIdx = outRec.Idx; //nb: do this after SetZ !
-          return newOp;
-        } else
-        {
-          OutRec outRec = m_PolyOuts[e.OutIdx];
-          //OutRec.Pts is the 'Left-most' point & OutRec.Pts.Prev is the 'Right-most'
-          OutPt op = outRec.Pts;
-          if (ToFront && pt == op.Pt) return op;
-          else if (!ToFront && pt == op.Prev.Pt) return op.Prev;
-
-          OutPt newOp = new OutPt();
-          newOp.Idx = outRec.Idx;
-          newOp.Pt = pt;
-          newOp.Next = op;
-          newOp.Prev = op.Prev;
-          newOp.Prev.Next = newOp;
-          op.Prev = newOp;
-          if (ToFront) outRec.Pts = newOp;
-          return newOp;
-        }
-      }
-      //------------------------------------------------------------------------------
-
-      internal void SwapPoints(ref IntPoint pt1, ref IntPoint pt2)
-      {
-          IntPoint tmp = new IntPoint(pt1);
-          pt1 = pt2;
-          pt2 = tmp;
-      }
-      //------------------------------------------------------------------------------
-
-      private bool HorzSegmentsOverlap(cInt seg1a, cInt seg1b, cInt seg2a, cInt seg2b)
-      {
-        if (seg1a > seg1b) Swap(ref seg1a, ref seg1b);
-        if (seg2a > seg2b) Swap(ref seg2a, ref seg2b);
-        return (seg1a < seg2b) && (seg2a < seg1b);
-      }
-      //------------------------------------------------------------------------------
-  
-      private void SetHoleState(TEdge e, OutRec outRec)
-      {
-          bool isHole = false;
-          TEdge e2 = e.PrevInAEL;
-          while (e2 != null)
-          {
-              if (e2.OutIdx >= 0 && e2.WindDelta != 0) 
-              {
-                  isHole = !isHole;
-                  if (outRec.FirstLeft == null)
-                      outRec.FirstLeft = m_PolyOuts[e2.OutIdx];
-              }
-              e2 = e2.PrevInAEL;
-          }
-          if (isHole) 
-            outRec.IsHole = true;
-      }
-      //------------------------------------------------------------------------------
-
-      private double GetDx(IntPoint pt1, IntPoint pt2)
-      {
-          if (pt1.Y == pt2.Y) return Horizontal;
-          else return (double)(pt2.X - pt1.X) / (pt2.Y - pt1.Y);
-      }
-      //---------------------------------------------------------------------------
-
-      private bool FirstIsBottomPt(OutPt btmPt1, OutPt btmPt2)
-      {
-        OutPt p = btmPt1.Prev;
-        while ((p.Pt == btmPt1.Pt) && (p != btmPt1)) p = p.Prev;
-        double dx1p = Math.Abs(GetDx(btmPt1.Pt, p.Pt));
-        p = btmPt1.Next;
-        while ((p.Pt == btmPt1.Pt) && (p != btmPt1)) p = p.Next;
-        double dx1n = Math.Abs(GetDx(btmPt1.Pt, p.Pt));
-
-        p = btmPt2.Prev;
-        while ((p.Pt == btmPt2.Pt) && (p != btmPt2)) p = p.Prev;
-        double dx2p = Math.Abs(GetDx(btmPt2.Pt, p.Pt));
-        p = btmPt2.Next;
-        while ((p.Pt == btmPt2.Pt) && (p != btmPt2)) p = p.Next;
-        double dx2n = Math.Abs(GetDx(btmPt2.Pt, p.Pt));
-        return (dx1p >= dx2p && dx1p >= dx2n) || (dx1n >= dx2p && dx1n >= dx2n);
-      }
-      //------------------------------------------------------------------------------
-
-      private OutPt GetBottomPt(OutPt pp)
-      {
-        OutPt dups = null;
-        OutPt p = pp.Next;
-        while (p != pp)
-        {
-          if (p.Pt.Y > pp.Pt.Y)
-          {
-            pp = p;
-            dups = null;
-          }
-          else if (p.Pt.Y == pp.Pt.Y && p.Pt.X <= pp.Pt.X)
-          {
-            if (p.Pt.X < pp.Pt.X)
             {
-                dups = null;
-                pp = p;
-            } else
-            {
-              if (p.Next != pp && p.Prev != pp) dups = p;
+                if (e2.Side == EdgeSide.esRight)
+                {
+                    //a b c z y x
+                    ReversePolyPtLinks(p2_lft);
+                    p1_rt.Next = p2_rt;
+                    p2_rt.Prev = p1_rt;
+                    p2_lft.Next = p1_lft;
+                    p1_lft.Prev = p2_lft;
+                }
+                else
+                {
+                    //a b c x y z
+                    p1_rt.Next = p2_lft;
+                    p2_lft.Prev = p1_rt;
+                    p1_lft.Prev = p2_rt;
+                    p2_rt.Next = p1_lft;
+                }
+                side = EdgeSide.esRight;
             }
-          }
-          p = p.Next;
+
+            outRec1.BottomPt = null;
+            if (holeStateRec == outRec2)
+            {
+                if (outRec2.FirstLeft != outRec1)
+                    outRec1.FirstLeft = outRec2.FirstLeft;
+                outRec1.IsHole = outRec2.IsHole;
+            }
+            outRec2.Pts = null;
+            outRec2.BottomPt = null;
+
+            outRec2.FirstLeft = outRec1;
+
+            int OKIdx = e1.OutIdx;
+            int ObsoleteIdx = e2.OutIdx;
+
+            e1.OutIdx = Unassigned; //nb: safe because we only get here via AddLocalMaxPoly
+            e2.OutIdx = Unassigned;
+
+            TEdge e = m_ActiveEdges;
+            while (e != null)
+            {
+                if (e.OutIdx == ObsoleteIdx)
+                {
+                    e.OutIdx = OKIdx;
+                    e.Side = side;
+                    break;
+                }
+                e = e.NextInAEL;
+            }
+            outRec2.Idx = outRec1.Idx;
         }
-        if (dups != null)
+        //------------------------------------------------------------------------------
+
+        private void ReversePolyPtLinks(OutPt pp)
         {
-          //there appears to be at least 2 vertices at bottomPt so ...
-          while (dups != p)
-          {
-            if (!FirstIsBottomPt(p, dups)) pp = dups;
-            dups = dups.Next;
-            while (dups.Pt != pp.Pt) dups = dups.Next;
-          }
+            if (pp == null) return;
+            OutPt pp1;
+            OutPt pp2;
+            pp1 = pp;
+            do
+            {
+                pp2 = pp1.Next;
+                pp1.Next = pp1.Prev;
+                pp1.Prev = pp2;
+                pp1 = pp2;
+            } while (pp1 != pp);
         }
-        return pp;
-      }
-      //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-      private OutRec GetLowermostRec(OutRec outRec1, OutRec outRec2)
-      {
-          //work out which polygon fragment has the correct hole state ...
-          if (outRec1.BottomPt == null) 
-              outRec1.BottomPt = GetBottomPt(outRec1.Pts);
-          if (outRec2.BottomPt == null) 
-              outRec2.BottomPt = GetBottomPt(outRec2.Pts);
-          OutPt bPt1 = outRec1.BottomPt;
-          OutPt bPt2 = outRec2.BottomPt;
-          if (bPt1.Pt.Y > bPt2.Pt.Y) return outRec1;
-          else if (bPt1.Pt.Y < bPt2.Pt.Y) return outRec2;
-          else if (bPt1.Pt.X < bPt2.Pt.X) return outRec1;
-          else if (bPt1.Pt.X > bPt2.Pt.X) return outRec2;
-          else if (bPt1.Next == bPt1) return outRec2;
-          else if (bPt2.Next == bPt2) return outRec1;
-          else if (FirstIsBottomPt(bPt1, bPt2)) return outRec1;
-          else return outRec2;
-      }
-      //------------------------------------------------------------------------------
-
-      bool Param1RightOfParam2(OutRec outRec1, OutRec outRec2)
-      {
-          do
-          {
-              outRec1 = outRec1.FirstLeft;
-              if (outRec1 == outRec2) return true;
-          } while (outRec1 != null);
-          return false;
-      }
-      //------------------------------------------------------------------------------
-
-      private OutRec GetOutRec(int idx)
-      {
-        OutRec outrec = m_PolyOuts[idx];
-        while (outrec != m_PolyOuts[outrec.Idx])
-          outrec = m_PolyOuts[outrec.Idx];
-        return outrec;
-      }
-      //------------------------------------------------------------------------------
-
-      private void AppendPolygon(TEdge e1, TEdge e2)
-      {
-        //get the start and ends of both output polygons ...
-        OutRec outRec1 = m_PolyOuts[e1.OutIdx];
-        OutRec outRec2 = m_PolyOuts[e2.OutIdx];
-
-        OutRec holeStateRec;
-        if (Param1RightOfParam2(outRec1, outRec2)) 
-            holeStateRec = outRec2;
-        else if (Param1RightOfParam2(outRec2, outRec1))
-            holeStateRec = outRec1;
-        else
-            holeStateRec = GetLowermostRec(outRec1, outRec2);
-
-        OutPt p1_lft = outRec1.Pts;
-        OutPt p1_rt = p1_lft.Prev;
-        OutPt p2_lft = outRec2.Pts;
-        OutPt p2_rt = p2_lft.Prev;
-
-        EdgeSide side;
-        //join e2 poly onto e1 poly and delete pointers to e2 ...
-        if(  e1.Side == EdgeSide.esLeft )
+        private static void SwapSides(TEdge edge1, TEdge edge2)
         {
-          if (e2.Side == EdgeSide.esLeft)
-          {
-            //z y x a b c
-            ReversePolyPtLinks(p2_lft);
-            p2_lft.Next = p1_lft;
-            p1_lft.Prev = p2_lft;
-            p1_rt.Next = p2_rt;
-            p2_rt.Prev = p1_rt;
-            outRec1.Pts = p2_rt;
-          } else
-          {
-            //x y z a b c
-            p2_rt.Next = p1_lft;
-            p1_lft.Prev = p2_rt;
-            p2_lft.Prev = p1_rt;
-            p1_rt.Next = p2_lft;
-            outRec1.Pts = p2_lft;
-          }
-          side = EdgeSide.esLeft;
-        } else
-        {
-          if (e2.Side == EdgeSide.esRight)
-          {
-            //a b c z y x
-            ReversePolyPtLinks( p2_lft );
-            p1_rt.Next = p2_rt;
-            p2_rt.Prev = p1_rt;
-            p2_lft.Next = p1_lft;
-            p1_lft.Prev = p2_lft;
-          } else
-          {
-            //a b c x y z
-            p1_rt.Next = p2_lft;
-            p2_lft.Prev = p1_rt;
-            p1_lft.Prev = p2_rt;
-            p2_rt.Next = p1_lft;
-          }
-          side = EdgeSide.esRight;
+            EdgeSide side = edge1.Side;
+            edge1.Side = edge2.Side;
+            edge2.Side = side;
         }
+        //------------------------------------------------------------------------------
 
-        outRec1.BottomPt = null; 
-        if (holeStateRec == outRec2)
+        private static void SwapPolyIndexes(TEdge edge1, TEdge edge2)
         {
-            if (outRec2.FirstLeft != outRec1)
-                outRec1.FirstLeft = outRec2.FirstLeft;
-            outRec1.IsHole = outRec2.IsHole;
+            int outIdx = edge1.OutIdx;
+            edge1.OutIdx = edge2.OutIdx;
+            edge2.OutIdx = outIdx;
         }
-        outRec2.Pts = null;
-        outRec2.BottomPt = null;
+        //------------------------------------------------------------------------------
 
-        outRec2.FirstLeft = outRec1;
-
-        int OKIdx = e1.OutIdx;
-        int ObsoleteIdx = e2.OutIdx;
-
-        e1.OutIdx = Unassigned; //nb: safe because we only get here via AddLocalMaxPoly
-        e2.OutIdx = Unassigned;
-
-        TEdge e = m_ActiveEdges;
-        while( e != null )
+        private void IntersectEdges(TEdge e1, TEdge e2, IntPoint pt)
         {
-          if( e.OutIdx == ObsoleteIdx )
-          {
-            e.OutIdx = OKIdx;
-            e.Side = side;
-            break;
-          }
-          e = e.NextInAEL;
-        }
-        outRec2.Idx = outRec1.Idx;
-      }
-      //------------------------------------------------------------------------------
+            //e1 will be to the left of e2 BELOW the intersection. Therefore e1 is before
+            //e2 in AEL except when e1 is being inserted at the intersection point ...
 
-      private void ReversePolyPtLinks(OutPt pp)
-      {
-          if (pp == null) return;
-          OutPt pp1;
-          OutPt pp2;
-          pp1 = pp;
-          do
-          {
-              pp2 = pp1.Next;
-              pp1.Next = pp1.Prev;
-              pp1.Prev = pp2;
-              pp1 = pp2;
-          } while (pp1 != pp);
-      }
-      //------------------------------------------------------------------------------
-
-      private static void SwapSides(TEdge edge1, TEdge edge2)
-      {
-          EdgeSide side = edge1.Side;
-          edge1.Side = edge2.Side;
-          edge2.Side = side;
-      }
-      //------------------------------------------------------------------------------
-
-      private static void SwapPolyIndexes(TEdge edge1, TEdge edge2)
-      {
-          int outIdx = edge1.OutIdx;
-          edge1.OutIdx = edge2.OutIdx;
-          edge2.OutIdx = outIdx;
-      }
-      //------------------------------------------------------------------------------
-
-      private void IntersectEdges(TEdge e1, TEdge e2, IntPoint pt)
-      {
-          //e1 will be to the left of e2 BELOW the intersection. Therefore e1 is before
-          //e2 in AEL except when e1 is being inserted at the intersection point ...
-
-        bool e1Contributing = (e1.OutIdx >= 0);
-        bool e2Contributing = (e2.OutIdx >= 0);
+            bool e1Contributing = (e1.OutIdx >= 0);
+            bool e2Contributing = (e2.OutIdx >= 0);
 
 #if use_xyz
           SetZ(ref pt, e1, e2);
@@ -2449,736 +2459,740 @@ namespace TVGL.Boolean_Operations.Clipper
           }
 #endif
 
-          //update winding counts...
-  //assumes that e1 will be to the Right of e2 ABOVE the intersection
-          if (e1.PolyTyp == e2.PolyTyp)
-          {
-              if (IsEvenOddFillType(e1))
-              {
-                  int oldE1WindCnt = e1.WindCnt;
-                  e1.WindCnt = e2.WindCnt;
-                  e2.WindCnt = oldE1WindCnt;
-              }
-              else
-              {
-                  if (e1.WindCnt + e2.WindDelta == 0) e1.WindCnt = -e1.WindCnt;
-                  else e1.WindCnt += e2.WindDelta;
-                  if (e2.WindCnt - e1.WindDelta == 0) e2.WindCnt = -e2.WindCnt;
-                  else e2.WindCnt -= e1.WindDelta;
-              }
-          }
-          else
-          {
-              if (!IsEvenOddFillType(e2)) e1.WindCnt2 += e2.WindDelta;
-              else e1.WindCnt2 = (e1.WindCnt2 == 0) ? 1 : 0;
-              if (!IsEvenOddFillType(e1)) e2.WindCnt2 -= e1.WindDelta;
-              else e2.WindCnt2 = (e2.WindCnt2 == 0) ? 1 : 0;
-          }
-
-          PolyFillType e1FillType, e2FillType, e1FillType2, e2FillType2;
-          if (e1.PolyTyp == PolyType.ptSubject)
-          {
-              e1FillType = m_SubjFillType;
-              e1FillType2 = m_ClipFillType;
-          }
-          else
-          {
-              e1FillType = m_ClipFillType;
-              e1FillType2 = m_SubjFillType;
-          }
-          if (e2.PolyTyp == PolyType.ptSubject)
-          {
-              e2FillType = m_SubjFillType;
-              e2FillType2 = m_ClipFillType;
-          }
-          else
-          {
-              e2FillType = m_ClipFillType;
-              e2FillType2 = m_SubjFillType;
-          }
-
-          int e1Wc, e2Wc;
-          switch (e1FillType)
-          {
-              case PolyFillType.pftPositive: e1Wc = e1.WindCnt; break;
-              case PolyFillType.pftNegative: e1Wc = -e1.WindCnt; break;
-              default: e1Wc = Math.Abs(e1.WindCnt); break;
-          }
-          switch (e2FillType)
-          {
-              case PolyFillType.pftPositive: e2Wc = e2.WindCnt; break;
-              case PolyFillType.pftNegative: e2Wc = -e2.WindCnt; break;
-              default: e2Wc = Math.Abs(e2.WindCnt); break;
-          }
-
-          if (e1Contributing && e2Contributing)
-          {
-            if ((e1Wc != 0 && e1Wc != 1) || (e2Wc != 0 && e2Wc != 1) ||
-              (e1.PolyTyp != e2.PolyTyp && m_ClipType != ClipType.ctXor))
+            //update winding counts...
+            //assumes that e1 will be to the Right of e2 ABOVE the intersection
+            if (e1.PolyTyp == e2.PolyTyp)
             {
-              AddLocalMaxPoly(e1, e2, pt);
+                if (IsEvenOddFillType(e1))
+                {
+                    int oldE1WindCnt = e1.WindCnt;
+                    e1.WindCnt = e2.WindCnt;
+                    e2.WindCnt = oldE1WindCnt;
+                }
+                else
+                {
+                    if (e1.WindCnt + e2.WindDelta == 0) e1.WindCnt = -e1.WindCnt;
+                    else e1.WindCnt += e2.WindDelta;
+                    if (e2.WindCnt - e1.WindDelta == 0) e2.WindCnt = -e2.WindCnt;
+                    else e2.WindCnt -= e1.WindDelta;
+                }
             }
             else
             {
-              AddOutPt(e1, pt);
-              AddOutPt(e2, pt);
-              SwapSides(e1, e2);
-              SwapPolyIndexes(e1, e2);
+                if (!IsEvenOddFillType(e2)) e1.WindCnt2 += e2.WindDelta;
+                else e1.WindCnt2 = (e1.WindCnt2 == 0) ? 1 : 0;
+                if (!IsEvenOddFillType(e1)) e2.WindCnt2 -= e1.WindDelta;
+                else e2.WindCnt2 = (e2.WindCnt2 == 0) ? 1 : 0;
             }
-          }
-          else if (e1Contributing)
-          {
-              if (e2Wc == 0 || e2Wc == 1)
-              {
-                AddOutPt(e1, pt);
-                SwapSides(e1, e2);
-                SwapPolyIndexes(e1, e2);
-              }
 
-          }
-          else if (e2Contributing)
-          {
-              if (e1Wc == 0 || e1Wc == 1)
-              {
-                AddOutPt(e2, pt);
-                SwapSides(e1, e2);
-                SwapPolyIndexes(e1, e2);
-              }
-          }
-          else if ( (e1Wc == 0 || e1Wc == 1) && (e2Wc == 0 || e2Wc == 1))
-          {
-              //neither edge is currently contributing ...
-              cInt e1Wc2, e2Wc2;
-              switch (e1FillType2)
-              {
-                  case PolyFillType.pftPositive: e1Wc2 = e1.WindCnt2; break;
-                  case PolyFillType.pftNegative: e1Wc2 = -e1.WindCnt2; break;
-                  default: e1Wc2 = Math.Abs(e1.WindCnt2); break;
-              }
-              switch (e2FillType2)
-              {
-                  case PolyFillType.pftPositive: e2Wc2 = e2.WindCnt2; break;
-                  case PolyFillType.pftNegative: e2Wc2 = -e2.WindCnt2; break;
-                  default: e2Wc2 = Math.Abs(e2.WindCnt2); break;
-              }
-
-              if (e1.PolyTyp != e2.PolyTyp)
-              {
-                AddLocalMinPoly(e1, e2, pt);
-              }
-              else if (e1Wc == 1 && e2Wc == 1)
-                switch (m_ClipType)
-                {
-                  case ClipType.ctIntersection:
-                    if (e1Wc2 > 0 && e2Wc2 > 0)
-                      AddLocalMinPoly(e1, e2, pt);
-                    break;
-                  case ClipType.ctUnion:
-                    if (e1Wc2 <= 0 && e2Wc2 <= 0)
-                      AddLocalMinPoly(e1, e2, pt);
-                    break;
-                  case ClipType.ctDifference:
-                    if (((e1.PolyTyp == PolyType.ptClip) && (e1Wc2 > 0) && (e2Wc2 > 0)) ||
-                        ((e1.PolyTyp == PolyType.ptSubject) && (e1Wc2 <= 0) && (e2Wc2 <= 0)))
-                          AddLocalMinPoly(e1, e2, pt);
-                    break;
-                  case ClipType.ctXor:
-                    AddLocalMinPoly(e1, e2, pt);
-                    break;
-                }
-              else
-                SwapSides(e1, e2);
-          }
-      }
-      //------------------------------------------------------------------------------
-
-      private void DeleteFromAEL(TEdge e)
-      {
-          TEdge AelPrev = e.PrevInAEL;
-          TEdge AelNext = e.NextInAEL;
-          if (AelPrev == null && AelNext == null && (e != m_ActiveEdges))
-              return; //already deleted
-          if (AelPrev != null)
-              AelPrev.NextInAEL = AelNext;
-          else m_ActiveEdges = AelNext;
-          if (AelNext != null)
-              AelNext.PrevInAEL = AelPrev;
-          e.NextInAEL = null;
-          e.PrevInAEL = null;
-      }
-      //------------------------------------------------------------------------------
-
-      private void DeleteFromSEL(TEdge e)
-      {
-          TEdge SelPrev = e.PrevInSEL;
-          TEdge SelNext = e.NextInSEL;
-          if (SelPrev == null && SelNext == null && (e != m_SortedEdges))
-              return; //already deleted
-          if (SelPrev != null)
-              SelPrev.NextInSEL = SelNext;
-          else m_SortedEdges = SelNext;
-          if (SelNext != null)
-              SelNext.PrevInSEL = SelPrev;
-          e.NextInSEL = null;
-          e.PrevInSEL = null;
-      }
-      //------------------------------------------------------------------------------
-
-      private void UpdateEdgeIntoAEL(ref TEdge e)
-      {
-          if (e.NextInLML == null)
-              throw new ClipperException("UpdateEdgeIntoAEL: invalid call");
-          TEdge AelPrev = e.PrevInAEL;
-          TEdge AelNext = e.NextInAEL;
-          e.NextInLML.OutIdx = e.OutIdx;
-          if (AelPrev != null)
-              AelPrev.NextInAEL = e.NextInLML;
-          else m_ActiveEdges = e.NextInLML;
-          if (AelNext != null)
-              AelNext.PrevInAEL = e.NextInLML;
-          e.NextInLML.Side = e.Side;
-          e.NextInLML.WindDelta = e.WindDelta;
-          e.NextInLML.WindCnt = e.WindCnt;
-          e.NextInLML.WindCnt2 = e.WindCnt2;
-          e = e.NextInLML;
-          e.Curr = e.Bot;
-          e.PrevInAEL = AelPrev;
-          e.NextInAEL = AelNext;
-          if (!IsHorizontal(e)) InsertScanbeam(e.Top.Y);
-      }
-      //------------------------------------------------------------------------------
-
-      private void ProcessHorizontals(bool isTopOfScanbeam)
-      {
-          TEdge horzEdge = m_SortedEdges;
-          while (horzEdge != null)
-          {
-              DeleteFromSEL(horzEdge);
-              ProcessHorizontal(horzEdge, isTopOfScanbeam);
-              horzEdge = m_SortedEdges;
-          }
-      }
-      //------------------------------------------------------------------------------
-
-      void GetHorzDirection(TEdge HorzEdge, out Direction Dir, out cInt Left, out cInt Right)
-      {
-        if (HorzEdge.Bot.X < HorzEdge.Top.X)
-        {
-          Left = HorzEdge.Bot.X;
-          Right = HorzEdge.Top.X;
-          Dir = Direction.dLeftToRight;
-        } else
-        {
-          Left = HorzEdge.Top.X;
-          Right = HorzEdge.Bot.X;
-          Dir = Direction.dRightToLeft;
-        }
-      }
-      //------------------------------------------------------------------------
-
-      private void ProcessHorizontal(TEdge horzEdge, bool isTopOfScanbeam)
-      {
-        Direction dir;
-        cInt horzLeft, horzRight;
-
-        GetHorzDirection(horzEdge, out dir, out horzLeft, out horzRight);
-
-        TEdge eLastHorz = horzEdge, eMaxPair = null;
-        while (eLastHorz.NextInLML != null && IsHorizontal(eLastHorz.NextInLML)) 
-          eLastHorz = eLastHorz.NextInLML;
-        if (eLastHorz.NextInLML == null)
-          eMaxPair = GetMaximaPair(eLastHorz);
-
-        for (;;)
-        {
-          bool IsLastHorz = (horzEdge == eLastHorz);
-          TEdge e = GetNextInAEL(horzEdge, dir);
-          while(e != null)
-          {
-            //Break if we've got to the end of an intermediate horizontal edge ...
-            //nb: Smaller Dx's are to the right of larger Dx's ABOVE the horizontal.
-            if (e.Curr.X == horzEdge.Top.X && horzEdge.NextInLML != null && 
-              e.Dx < horzEdge.NextInLML.Dx) break;
-
-            TEdge eNext = GetNextInAEL(e, dir); //saves eNext for later
-
-            if ((dir == Direction.dLeftToRight && e.Curr.X <= horzRight) ||
-              (dir == Direction.dRightToLeft && e.Curr.X >= horzLeft))
+            PolyFillType e1FillType, e2FillType, e1FillType2, e2FillType2;
+            if (e1.PolyTyp == PolyType.ptSubject)
             {
-              //so far we're still in range of the horizontal Edge  but make sure
-              //we're at the last of consec. horizontals when matching with eMaxPair
-              if(e == eMaxPair && IsLastHorz)
-              {
+                e1FillType = m_SubjFillType;
+                e1FillType2 = m_ClipFillType;
+            }
+            else
+            {
+                e1FillType = m_ClipFillType;
+                e1FillType2 = m_SubjFillType;
+            }
+            if (e2.PolyTyp == PolyType.ptSubject)
+            {
+                e2FillType = m_SubjFillType;
+                e2FillType2 = m_ClipFillType;
+            }
+            else
+            {
+                e2FillType = m_ClipFillType;
+                e2FillType2 = m_SubjFillType;
+            }
+
+            int e1Wc, e2Wc;
+            switch (e1FillType)
+            {
+                case PolyFillType.pftPositive: e1Wc = e1.WindCnt; break;
+                case PolyFillType.pftNegative: e1Wc = -e1.WindCnt; break;
+                default: e1Wc = Math.Abs(e1.WindCnt); break;
+            }
+            switch (e2FillType)
+            {
+                case PolyFillType.pftPositive: e2Wc = e2.WindCnt; break;
+                case PolyFillType.pftNegative: e2Wc = -e2.WindCnt; break;
+                default: e2Wc = Math.Abs(e2.WindCnt); break;
+            }
+
+            if (e1Contributing && e2Contributing)
+            {
+                if ((e1Wc != 0 && e1Wc != 1) || (e2Wc != 0 && e2Wc != 1) ||
+                  (e1.PolyTyp != e2.PolyTyp && m_ClipType != ClipType.ctXor))
+                {
+                    AddLocalMaxPoly(e1, e2, pt);
+                }
+                else
+                {
+                    AddOutPt(e1, pt);
+                    AddOutPt(e2, pt);
+                    SwapSides(e1, e2);
+                    SwapPolyIndexes(e1, e2);
+                }
+            }
+            else if (e1Contributing)
+            {
+                if (e2Wc == 0 || e2Wc == 1)
+                {
+                    AddOutPt(e1, pt);
+                    SwapSides(e1, e2);
+                    SwapPolyIndexes(e1, e2);
+                }
+
+            }
+            else if (e2Contributing)
+            {
+                if (e1Wc == 0 || e1Wc == 1)
+                {
+                    AddOutPt(e2, pt);
+                    SwapSides(e1, e2);
+                    SwapPolyIndexes(e1, e2);
+                }
+            }
+            else if ((e1Wc == 0 || e1Wc == 1) && (e2Wc == 0 || e2Wc == 1))
+            {
+                //neither edge is currently contributing ...
+                cInt e1Wc2, e2Wc2;
+                switch (e1FillType2)
+                {
+                    case PolyFillType.pftPositive: e1Wc2 = e1.WindCnt2; break;
+                    case PolyFillType.pftNegative: e1Wc2 = -e1.WindCnt2; break;
+                    default: e1Wc2 = Math.Abs(e1.WindCnt2); break;
+                }
+                switch (e2FillType2)
+                {
+                    case PolyFillType.pftPositive: e2Wc2 = e2.WindCnt2; break;
+                    case PolyFillType.pftNegative: e2Wc2 = -e2.WindCnt2; break;
+                    default: e2Wc2 = Math.Abs(e2.WindCnt2); break;
+                }
+
+                if (e1.PolyTyp != e2.PolyTyp)
+                {
+                    AddLocalMinPoly(e1, e2, pt);
+                }
+                else if (e1Wc == 1 && e2Wc == 1)
+                    switch (m_ClipType)
+                    {
+                        case ClipType.ctIntersection:
+                            if (e1Wc2 > 0 && e2Wc2 > 0)
+                                AddLocalMinPoly(e1, e2, pt);
+                            break;
+                        case ClipType.ctUnion:
+                            if (e1Wc2 <= 0 && e2Wc2 <= 0)
+                                AddLocalMinPoly(e1, e2, pt);
+                            break;
+                        case ClipType.ctDifference:
+                            if (((e1.PolyTyp == PolyType.ptClip) && (e1Wc2 > 0) && (e2Wc2 > 0)) ||
+                                ((e1.PolyTyp == PolyType.ptSubject) && (e1Wc2 <= 0) && (e2Wc2 <= 0)))
+                                AddLocalMinPoly(e1, e2, pt);
+                            break;
+                        case ClipType.ctXor:
+                            AddLocalMinPoly(e1, e2, pt);
+                            break;
+                    }
+                else
+                    SwapSides(e1, e2);
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        private void DeleteFromAEL(TEdge e)
+        {
+            TEdge AelPrev = e.PrevInAEL;
+            TEdge AelNext = e.NextInAEL;
+            if (AelPrev == null && AelNext == null && (e != m_ActiveEdges))
+                return; //already deleted
+            if (AelPrev != null)
+                AelPrev.NextInAEL = AelNext;
+            else m_ActiveEdges = AelNext;
+            if (AelNext != null)
+                AelNext.PrevInAEL = AelPrev;
+            e.NextInAEL = null;
+            e.PrevInAEL = null;
+        }
+        //------------------------------------------------------------------------------
+
+        private void DeleteFromSEL(TEdge e)
+        {
+            TEdge SelPrev = e.PrevInSEL;
+            TEdge SelNext = e.NextInSEL;
+            if (SelPrev == null && SelNext == null && (e != m_SortedEdges))
+                return; //already deleted
+            if (SelPrev != null)
+                SelPrev.NextInSEL = SelNext;
+            else m_SortedEdges = SelNext;
+            if (SelNext != null)
+                SelNext.PrevInSEL = SelPrev;
+            e.NextInSEL = null;
+            e.PrevInSEL = null;
+        }
+        //------------------------------------------------------------------------------
+
+        private void UpdateEdgeIntoAEL(ref TEdge e)
+        {
+            if (e.NextInLML == null)
+                throw new ClipperException("UpdateEdgeIntoAEL: invalid call");
+            TEdge AelPrev = e.PrevInAEL;
+            TEdge AelNext = e.NextInAEL;
+            e.NextInLML.OutIdx = e.OutIdx;
+            if (AelPrev != null)
+                AelPrev.NextInAEL = e.NextInLML;
+            else m_ActiveEdges = e.NextInLML;
+            if (AelNext != null)
+                AelNext.PrevInAEL = e.NextInLML;
+            e.NextInLML.Side = e.Side;
+            e.NextInLML.WindDelta = e.WindDelta;
+            e.NextInLML.WindCnt = e.WindCnt;
+            e.NextInLML.WindCnt2 = e.WindCnt2;
+            e = e.NextInLML;
+            e.Curr = e.Bot;
+            e.PrevInAEL = AelPrev;
+            e.NextInAEL = AelNext;
+            if (!IsHorizontal(e)) InsertScanbeam(e.Top.Y);
+        }
+        //------------------------------------------------------------------------------
+
+        private void ProcessHorizontals(bool isTopOfScanbeam)
+        {
+            TEdge horzEdge = m_SortedEdges;
+            while (horzEdge != null)
+            {
+                DeleteFromSEL(horzEdge);
+                ProcessHorizontal(horzEdge, isTopOfScanbeam);
+                horzEdge = m_SortedEdges;
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        void GetHorzDirection(TEdge HorzEdge, out Direction Dir, out cInt Left, out cInt Right)
+        {
+            if (HorzEdge.Bot.X < HorzEdge.Top.X)
+            {
+                Left = HorzEdge.Bot.X;
+                Right = HorzEdge.Top.X;
+                Dir = Direction.dLeftToRight;
+            }
+            else
+            {
+                Left = HorzEdge.Top.X;
+                Right = HorzEdge.Bot.X;
+                Dir = Direction.dRightToLeft;
+            }
+        }
+        //------------------------------------------------------------------------
+
+        private void ProcessHorizontal(TEdge horzEdge, bool isTopOfScanbeam)
+        {
+            Direction dir;
+            cInt horzLeft, horzRight;
+
+            GetHorzDirection(horzEdge, out dir, out horzLeft, out horzRight);
+
+            TEdge eLastHorz = horzEdge, eMaxPair = null;
+            while (eLastHorz.NextInLML != null && IsHorizontal(eLastHorz.NextInLML))
+                eLastHorz = eLastHorz.NextInLML;
+            if (eLastHorz.NextInLML == null)
+                eMaxPair = GetMaximaPair(eLastHorz);
+
+            for (;;)
+            {
+                bool IsLastHorz = (horzEdge == eLastHorz);
+                TEdge e = GetNextInAEL(horzEdge, dir);
+                while (e != null)
+                {
+                    //Break if we've got to the end of an intermediate horizontal edge ...
+                    //nb: Smaller Dx's are to the right of larger Dx's ABOVE the horizontal.
+                    if (e.Curr.X == horzEdge.Top.X && horzEdge.NextInLML != null &&
+                      e.Dx < horzEdge.NextInLML.Dx) break;
+
+                    TEdge eNext = GetNextInAEL(e, dir); //saves eNext for later
+
+                    if ((dir == Direction.dLeftToRight && e.Curr.X <= horzRight) ||
+                      (dir == Direction.dRightToLeft && e.Curr.X >= horzLeft))
+                    {
+                        //so far we're still in range of the horizontal Edge  but make sure
+                        //we're at the last of consec. horizontals when matching with eMaxPair
+                        if (e == eMaxPair && IsLastHorz)
+                        {
+                            if (horzEdge.OutIdx >= 0)
+                            {
+                                OutPt op1 = AddOutPt(horzEdge, horzEdge.Top);
+                                TEdge eNextHorz = m_SortedEdges;
+                                while (eNextHorz != null)
+                                {
+                                    if (eNextHorz.OutIdx >= 0 &&
+                                      HorzSegmentsOverlap(horzEdge.Bot.X,
+                                      horzEdge.Top.X, eNextHorz.Bot.X, eNextHorz.Top.X))
+                                    {
+                                        OutPt op2 = AddOutPt(eNextHorz, eNextHorz.Bot);
+                                        AddJoin(op2, op1, eNextHorz.Top);
+                                    }
+                                    eNextHorz = eNextHorz.NextInSEL;
+                                }
+                                AddGhostJoin(op1, horzEdge.Bot);
+                                AddLocalMaxPoly(horzEdge, eMaxPair, horzEdge.Top);
+                            }
+                            DeleteFromAEL(horzEdge);
+                            DeleteFromAEL(eMaxPair);
+                            return;
+                        }
+                        else if (dir == Direction.dLeftToRight)
+                        {
+                            IntPoint Pt = new IntPoint(e.Curr.X, horzEdge.Curr.Y);
+                            IntersectEdges(horzEdge, e, Pt);
+                        }
+                        else
+                        {
+                            IntPoint Pt = new IntPoint(e.Curr.X, horzEdge.Curr.Y);
+                            IntersectEdges(e, horzEdge, Pt);
+                        }
+                        SwapPositionsInAEL(horzEdge, e);
+                    }
+                    else if ((dir == Direction.dLeftToRight && e.Curr.X >= horzRight) ||
+                      (dir == Direction.dRightToLeft && e.Curr.X <= horzLeft)) break;
+                    e = eNext;
+                } //end while
+
+                if (horzEdge.NextInLML != null && IsHorizontal(horzEdge.NextInLML))
+                {
+                    UpdateEdgeIntoAEL(ref horzEdge);
+                    if (horzEdge.OutIdx >= 0) AddOutPt(horzEdge, horzEdge.Bot);
+                    GetHorzDirection(horzEdge, out dir, out horzLeft, out horzRight);
+                }
+                else
+                    break;
+            } //end for (;;)
+
+            if (horzEdge.NextInLML != null)
+            {
                 if (horzEdge.OutIdx >= 0)
                 {
-                  OutPt op1 = AddOutPt(horzEdge, horzEdge.Top);
-                  TEdge eNextHorz = m_SortedEdges;
-                  while (eNextHorz != null)
-                  {
-                    if (eNextHorz.OutIdx >= 0 &&
-                      HorzSegmentsOverlap(horzEdge.Bot.X,
-                      horzEdge.Top.X, eNextHorz.Bot.X, eNextHorz.Top.X))
+                    OutPt op1 = AddOutPt(horzEdge, horzEdge.Top);
+                    if (isTopOfScanbeam) AddGhostJoin(op1, horzEdge.Bot);
+
+                    UpdateEdgeIntoAEL(ref horzEdge);
+                    if (horzEdge.WindDelta == 0) return;
+                    //nb: HorzEdge is no longer horizontal here
+                    TEdge ePrev = horzEdge.PrevInAEL;
+                    TEdge eNext = horzEdge.NextInAEL;
+                    if (ePrev != null && ePrev.Curr.X == horzEdge.Bot.X &&
+                      ePrev.Curr.Y == horzEdge.Bot.Y && ePrev.WindDelta != 0 &&
+                      (ePrev.OutIdx >= 0 && ePrev.Curr.Y > ePrev.Top.Y &&
+                      SlopesEqual(horzEdge, ePrev, MUseFullRange)))
                     {
-                      OutPt op2 = AddOutPt(eNextHorz, eNextHorz.Bot);
-                      AddJoin(op2, op1, eNextHorz.Top);
+                        OutPt op2 = AddOutPt(ePrev, horzEdge.Bot);
+                        AddJoin(op1, op2, horzEdge.Top);
                     }
-                    eNextHorz = eNextHorz.NextInSEL;
-                  }
-                  AddGhostJoin(op1, horzEdge.Bot);
-                  AddLocalMaxPoly(horzEdge, eMaxPair, horzEdge.Top);
+                    else if (eNext != null && eNext.Curr.X == horzEdge.Bot.X &&
+                      eNext.Curr.Y == horzEdge.Bot.Y && eNext.WindDelta != 0 &&
+                      eNext.OutIdx >= 0 && eNext.Curr.Y > eNext.Top.Y &&
+                      SlopesEqual(horzEdge, eNext, MUseFullRange))
+                    {
+                        OutPt op2 = AddOutPt(eNext, horzEdge.Bot);
+                        AddJoin(op1, op2, horzEdge.Top);
+                    }
                 }
+                else
+                    UpdateEdgeIntoAEL(ref horzEdge);
+            }
+            else
+            {
+                if (horzEdge.OutIdx >= 0) AddOutPt(horzEdge, horzEdge.Top);
                 DeleteFromAEL(horzEdge);
-                DeleteFromAEL(eMaxPair);
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        private TEdge GetNextInAEL(TEdge e, Direction Direction)
+        {
+            return Direction == Direction.dLeftToRight ? e.NextInAEL : e.PrevInAEL;
+        }
+        //------------------------------------------------------------------------------
+
+        private bool IsMinima(TEdge e)
+        {
+            return e != null && (e.Prev.NextInLML != e) && (e.Next.NextInLML != e);
+        }
+        //------------------------------------------------------------------------------
+
+        private bool IsMaxima(TEdge e, double Y)
+        {
+            return (e != null && e.Top.Y == Y && e.NextInLML == null);
+        }
+        //------------------------------------------------------------------------------
+
+        private bool IsIntermediate(TEdge e, double Y)
+        {
+            return (e.Top.Y == Y && e.NextInLML != null);
+        }
+        //------------------------------------------------------------------------------
+
+        private TEdge GetMaximaPair(TEdge e)
+        {
+            TEdge result = null;
+            if ((e.Next.Top == e.Top) && e.Next.NextInLML == null)
+                result = e.Next;
+            else if ((e.Prev.Top == e.Top) && e.Prev.NextInLML == null)
+                result = e.Prev;
+            if (result != null && (result.OutIdx == Skip ||
+              (result.NextInAEL == result.PrevInAEL && !IsHorizontal(result))))
+                return null;
+            return result;
+        }
+        //------------------------------------------------------------------------------
+
+        private bool ProcessIntersections(cInt topY)
+        {
+            if (m_ActiveEdges == null) return true;
+            try
+            {
+                BuildIntersectList(topY);
+                if (m_IntersectList.Count == 0) return true;
+                if (m_IntersectList.Count == 1 || FixupIntersectionOrder())
+                    ProcessIntersectList();
+                else
+                    return false;
+            }
+            catch
+            {
+                m_SortedEdges = null;
+                m_IntersectList.Clear();
+                throw new ClipperException("ProcessIntersections error");
+            }
+            m_SortedEdges = null;
+            return true;
+        }
+        //------------------------------------------------------------------------------
+
+        private void BuildIntersectList(cInt topY)
+        {
+            if (m_ActiveEdges == null) return;
+
+            //prepare for sorting ...
+            TEdge e = m_ActiveEdges;
+            m_SortedEdges = e;
+            while (e != null)
+            {
+                e.PrevInSEL = e.PrevInAEL;
+                e.NextInSEL = e.NextInAEL;
+                e.Curr.X = TopX(e, topY);
+                e = e.NextInAEL;
+            }
+
+            //bubblesort ...
+            bool isModified = true;
+            while (isModified && m_SortedEdges != null)
+            {
+                isModified = false;
+                e = m_SortedEdges;
+                while (e.NextInSEL != null)
+                {
+                    TEdge eNext = e.NextInSEL;
+                    IntPoint pt;
+                    if (e.Curr.X > eNext.Curr.X)
+                    {
+                        IntersectPoint(e, eNext, out pt);
+                        IntersectNode newNode = new IntersectNode();
+                        newNode.Edge1 = e;
+                        newNode.Edge2 = eNext;
+                        newNode.Pt = pt;
+                        m_IntersectList.Add(newNode);
+
+                        SwapPositionsInSEL(e, eNext);
+                        isModified = true;
+                    }
+                    else
+                        e = eNext;
+                }
+                if (e.PrevInSEL != null) e.PrevInSEL.NextInSEL = null;
+                else break;
+            }
+            m_SortedEdges = null;
+        }
+        //------------------------------------------------------------------------------
+
+        private bool EdgesAdjacent(IntersectNode inode)
+        {
+            return (inode.Edge1.NextInSEL == inode.Edge2) ||
+              (inode.Edge1.PrevInSEL == inode.Edge2);
+        }
+        //------------------------------------------------------------------------------
+
+        private static int IntersectNodeSort(IntersectNode node1, IntersectNode node2)
+        {
+            //the following typecast is safe because the differences in Pt.Y will
+            //be limited to the height of the scanbeam.
+            return (int)(node2.Pt.Y - node1.Pt.Y);
+        }
+        //------------------------------------------------------------------------------
+
+        private bool FixupIntersectionOrder()
+        {
+            //pre-condition: intersections are sorted bottom-most first.
+            //Now it's crucial that intersections are made only between adjacent edges,
+            //so to ensure this the order of intersections may need adjusting ...
+            m_IntersectList.Sort(m_IntersectNodeComparer);
+
+            CopyAELToSEL();
+            int cnt = m_IntersectList.Count;
+            for (int i = 0; i < cnt; i++)
+            {
+                if (!EdgesAdjacent(m_IntersectList[i]))
+                {
+                    int j = i + 1;
+                    while (j < cnt && !EdgesAdjacent(m_IntersectList[j])) j++;
+                    if (j == cnt) return false;
+
+                    IntersectNode tmp = m_IntersectList[i];
+                    m_IntersectList[i] = m_IntersectList[j];
+                    m_IntersectList[j] = tmp;
+
+                }
+                SwapPositionsInSEL(m_IntersectList[i].Edge1, m_IntersectList[i].Edge2);
+            }
+            return true;
+        }
+        //------------------------------------------------------------------------------
+
+        private void ProcessIntersectList()
+        {
+            for (int i = 0; i < m_IntersectList.Count; i++)
+            {
+                IntersectNode iNode = m_IntersectList[i];
+                {
+                    IntersectEdges(iNode.Edge1, iNode.Edge2, iNode.Pt);
+                    SwapPositionsInAEL(iNode.Edge1, iNode.Edge2);
+                }
+            }
+            m_IntersectList.Clear();
+        }
+        //------------------------------------------------------------------------------
+
+        internal static cInt Round(double value)
+        {
+            return value < 0 ? (cInt)(value - 0.5) : (cInt)(value + 0.5);
+        }
+        //------------------------------------------------------------------------------
+
+        private static cInt TopX(TEdge edge, cInt currentY)
+        {
+            if (currentY == edge.Top.Y)
+                return edge.Top.X;
+            return edge.Bot.X + Round(edge.Dx * (currentY - edge.Bot.Y));
+        }
+        //------------------------------------------------------------------------------
+
+        private void IntersectPoint(TEdge edge1, TEdge edge2, out IntPoint ip)
+        {
+            ip = new IntPoint();
+            double b1, b2;
+            //nb: with very large coordinate values, it's possible for SlopesEqual() to 
+            //return false but for the edge.Dx value be equal due to double precision rounding.
+            if (edge1.Dx == edge2.Dx)
+            {
+                ip.Y = edge1.Curr.Y;
+                ip.X = TopX(edge1, ip.Y);
                 return;
-              }
-              else if(dir == Direction.dLeftToRight)
-              {
-                IntPoint Pt = new IntPoint(e.Curr.X, horzEdge.Curr.Y);
-                IntersectEdges(horzEdge, e, Pt);
-              }
-              else
-              {
-                IntPoint Pt = new IntPoint(e.Curr.X, horzEdge.Curr.Y);
-                IntersectEdges(e, horzEdge, Pt);
-              }
-              SwapPositionsInAEL(horzEdge, e);
             }
-            else if ((dir == Direction.dLeftToRight && e.Curr.X >= horzRight) ||
-              (dir == Direction.dRightToLeft && e.Curr.X <= horzLeft)) break;
-            e = eNext;
-          } //end while
 
-          if (horzEdge.NextInLML != null && IsHorizontal(horzEdge.NextInLML))
-          {
-            UpdateEdgeIntoAEL(ref horzEdge);
-            if (horzEdge.OutIdx >= 0) AddOutPt(horzEdge, horzEdge.Bot);
-            GetHorzDirection(horzEdge, out dir, out horzLeft, out horzRight);
-          } else
-            break;
-        } //end for (;;)
-
-        if(horzEdge.NextInLML != null)
-        {
-          if(horzEdge.OutIdx >= 0)
-          {
-            OutPt op1 = AddOutPt( horzEdge, horzEdge.Top);
-            if (isTopOfScanbeam) AddGhostJoin(op1, horzEdge.Bot);
-
-            UpdateEdgeIntoAEL(ref horzEdge);
-            if (horzEdge.WindDelta == 0) return;
-            //nb: HorzEdge is no longer horizontal here
-            TEdge ePrev = horzEdge.PrevInAEL;
-            TEdge eNext = horzEdge.NextInAEL;
-            if (ePrev != null && ePrev.Curr.X == horzEdge.Bot.X &&
-              ePrev.Curr.Y == horzEdge.Bot.Y && ePrev.WindDelta != 0 &&
-              (ePrev.OutIdx >= 0 && ePrev.Curr.Y > ePrev.Top.Y &&
-              SlopesEqual(horzEdge, ePrev, MUseFullRange)))
+            if (edge1.Delta.X == 0)
             {
-              OutPt op2 = AddOutPt(ePrev, horzEdge.Bot);
-              AddJoin(op1, op2, horzEdge.Top);
+                ip.X = edge1.Bot.X;
+                if (IsHorizontal(edge2))
+                {
+                    ip.Y = edge2.Bot.Y;
+                }
+                else
+                {
+                    b2 = edge2.Bot.Y - (edge2.Bot.X / edge2.Dx);
+                    ip.Y = Round(ip.X / edge2.Dx + b2);
+                }
             }
-            else if (eNext != null && eNext.Curr.X == horzEdge.Bot.X &&
-              eNext.Curr.Y == horzEdge.Bot.Y && eNext.WindDelta != 0 &&
-              eNext.OutIdx >= 0 && eNext.Curr.Y > eNext.Top.Y &&
-              SlopesEqual(horzEdge, eNext, MUseFullRange))
+            else if (edge2.Delta.X == 0)
             {
-              OutPt op2 = AddOutPt(eNext, horzEdge.Bot);
-              AddJoin(op1, op2, horzEdge.Top);
-            }
-          }
-          else
-            UpdateEdgeIntoAEL(ref horzEdge); 
-        }
-        else
-        {
-          if (horzEdge.OutIdx >= 0) AddOutPt(horzEdge, horzEdge.Top);
-          DeleteFromAEL(horzEdge);
-        }
-      }
-      //------------------------------------------------------------------------------
-
-      private TEdge GetNextInAEL(TEdge e, Direction Direction)
-      {
-          return Direction == Direction.dLeftToRight ? e.NextInAEL: e.PrevInAEL;
-      }
-      //------------------------------------------------------------------------------
-
-      private bool IsMinima(TEdge e)
-      {
-          return e != null && (e.Prev.NextInLML != e) && (e.Next.NextInLML != e);
-      }
-      //------------------------------------------------------------------------------
-
-      private bool IsMaxima(TEdge e, double Y)
-      {
-          return (e != null && e.Top.Y == Y && e.NextInLML == null);
-      }
-      //------------------------------------------------------------------------------
-
-      private bool IsIntermediate(TEdge e, double Y)
-      {
-          return (e.Top.Y == Y && e.NextInLML != null);
-      }
-      //------------------------------------------------------------------------------
-
-      private TEdge GetMaximaPair(TEdge e)
-      {
-        TEdge result = null;
-        if ((e.Next.Top == e.Top) && e.Next.NextInLML == null)
-          result = e.Next;
-        else if ((e.Prev.Top == e.Top) && e.Prev.NextInLML == null)
-          result = e.Prev;
-        if (result != null && (result.OutIdx == Skip ||
-          (result.NextInAEL == result.PrevInAEL && !IsHorizontal(result))))
-          return null;
-        return result;
-      }
-      //------------------------------------------------------------------------------
-
-      private bool ProcessIntersections(cInt topY)
-      {
-        if( m_ActiveEdges == null ) return true;
-        try {
-          BuildIntersectList(topY);
-          if ( m_IntersectList.Count == 0) return true;
-          if (m_IntersectList.Count == 1 || FixupIntersectionOrder()) 
-              ProcessIntersectList();
-          else 
-              return false;
-        }
-        catch {
-          m_SortedEdges = null;
-          m_IntersectList.Clear();
-          throw new ClipperException("ProcessIntersections error");
-        }
-        m_SortedEdges = null;
-        return true;
-      }
-      //------------------------------------------------------------------------------
-
-      private void BuildIntersectList(cInt topY)
-      {
-        if ( m_ActiveEdges == null ) return;
-
-        //prepare for sorting ...
-        TEdge e = m_ActiveEdges;
-        m_SortedEdges = e;
-        while( e != null )
-        {
-          e.PrevInSEL = e.PrevInAEL;
-          e.NextInSEL = e.NextInAEL;
-          e.Curr.X = TopX( e, topY );
-          e = e.NextInAEL;
-        }
-
-        //bubblesort ...
-        bool isModified = true;
-        while( isModified && m_SortedEdges != null )
-        {
-          isModified = false;
-          e = m_SortedEdges;
-          while( e.NextInSEL != null )
-          {
-            TEdge eNext = e.NextInSEL;
-            IntPoint pt;
-            if (e.Curr.X > eNext.Curr.X)
-            {
-                IntersectPoint(e, eNext, out pt);
-                IntersectNode newNode = new IntersectNode();
-                newNode.Edge1 = e;
-                newNode.Edge2 = eNext;
-                newNode.Pt = pt;
-                m_IntersectList.Add(newNode);
-
-                SwapPositionsInSEL(e, eNext);
-                isModified = true;
-            }
-            else
-              e = eNext;
-          }
-          if( e.PrevInSEL != null ) e.PrevInSEL.NextInSEL = null;
-          else break;
-        }
-        m_SortedEdges = null;
-      }
-      //------------------------------------------------------------------------------
-
-      private bool EdgesAdjacent(IntersectNode inode)
-      {
-        return (inode.Edge1.NextInSEL == inode.Edge2) ||
-          (inode.Edge1.PrevInSEL == inode.Edge2);
-      }
-      //------------------------------------------------------------------------------
-
-      private static int IntersectNodeSort(IntersectNode node1, IntersectNode node2)
-      {
-        //the following typecast is safe because the differences in Pt.Y will
-        //be limited to the height of the scanbeam.
-        return (int)(node2.Pt.Y - node1.Pt.Y); 
-      }
-      //------------------------------------------------------------------------------
-
-      private bool FixupIntersectionOrder()
-      {
-        //pre-condition: intersections are sorted bottom-most first.
-        //Now it's crucial that intersections are made only between adjacent edges,
-        //so to ensure this the order of intersections may need adjusting ...
-        m_IntersectList.Sort(m_IntersectNodeComparer);
-
-        CopyAELToSEL();
-        int cnt = m_IntersectList.Count;
-        for (int i = 0; i < cnt; i++)
-        {
-          if (!EdgesAdjacent(m_IntersectList[i]))
-          {
-            int j = i + 1;
-            while (j < cnt && !EdgesAdjacent(m_IntersectList[j])) j++;
-            if (j == cnt) return false;
-
-            IntersectNode tmp = m_IntersectList[i];
-            m_IntersectList[i] = m_IntersectList[j];
-            m_IntersectList[j] = tmp;
-
-          }
-          SwapPositionsInSEL(m_IntersectList[i].Edge1, m_IntersectList[i].Edge2);
-        }
-          return true;
-      }
-      //------------------------------------------------------------------------------
-
-      private void ProcessIntersectList()
-      {
-        for (int i = 0; i < m_IntersectList.Count; i++)
-        {
-          IntersectNode iNode = m_IntersectList[i];
-          {
-            IntersectEdges(iNode.Edge1, iNode.Edge2, iNode.Pt);
-            SwapPositionsInAEL(iNode.Edge1, iNode.Edge2);
-          }
-        }
-        m_IntersectList.Clear();
-      }
-      //------------------------------------------------------------------------------
-
-      internal static cInt Round(double value)
-      {
-          return value < 0 ? (cInt)(value - 0.5) : (cInt)(value + 0.5);
-      }
-      //------------------------------------------------------------------------------
-
-      private static cInt TopX(TEdge edge, cInt currentY)
-      {
-          if (currentY == edge.Top.Y)
-              return edge.Top.X;
-          return edge.Bot.X + Round(edge.Dx *(currentY - edge.Bot.Y));
-      }
-      //------------------------------------------------------------------------------
-
-      private void IntersectPoint(TEdge edge1, TEdge edge2, out IntPoint ip)
-      {
-        ip = new IntPoint();
-        double b1, b2;
-        //nb: with very large coordinate values, it's possible for SlopesEqual() to 
-        //return false but for the edge.Dx value be equal due to double precision rounding.
-        if (edge1.Dx == edge2.Dx)
-        {
-          ip.Y = edge1.Curr.Y;
-          ip.X = TopX(edge1, ip.Y);
-          return;
-        }
-
-        if (edge1.Delta.X == 0)
-        {
-            ip.X = edge1.Bot.X;
-            if (IsHorizontal(edge2))
-            {
-                ip.Y = edge2.Bot.Y;
+                ip.X = edge2.Bot.X;
+                if (IsHorizontal(edge1))
+                {
+                    ip.Y = edge1.Bot.Y;
+                }
+                else
+                {
+                    b1 = edge1.Bot.Y - (edge1.Bot.X / edge1.Dx);
+                    ip.Y = Round(ip.X / edge1.Dx + b1);
+                }
             }
             else
             {
-                b2 = edge2.Bot.Y - (edge2.Bot.X / edge2.Dx);
-                ip.Y = Round(ip.X / edge2.Dx + b2);
-            }
-        }
-        else if (edge2.Delta.X == 0)
-        {
-            ip.X = edge2.Bot.X;
-            if (IsHorizontal(edge1))
-            {
-                ip.Y = edge1.Bot.Y;
-            }
-            else
-            {
-                b1 = edge1.Bot.Y - (edge1.Bot.X / edge1.Dx);
-                ip.Y = Round(ip.X / edge1.Dx + b1);
-            }
-        }
-        else
-        {
-            b1 = edge1.Bot.X - edge1.Bot.Y * edge1.Dx;
-            b2 = edge2.Bot.X - edge2.Bot.Y * edge2.Dx;
-            double q = (b2 - b1) / (edge1.Dx - edge2.Dx);
-            ip.Y = Round(q);
-            if (Math.Abs(edge1.Dx) < Math.Abs(edge2.Dx))
-                ip.X = Round(edge1.Dx * q + b1);
-            else
-                ip.X = Round(edge2.Dx * q + b2);
-        }
-
-        if (ip.Y < edge1.Top.Y || ip.Y < edge2.Top.Y)
-        {
-          if (edge1.Top.Y > edge2.Top.Y)
-            ip.Y = edge1.Top.Y;
-          else
-            ip.Y = edge2.Top.Y;
-          if (Math.Abs(edge1.Dx) < Math.Abs(edge2.Dx))
-            ip.X = TopX(edge1, ip.Y);
-          else
-            ip.X = TopX(edge2, ip.Y);
-        }
-        //finally, don't allow 'ip' to be BELOW curr.Y (ie bottom of scanbeam) ...
-        if (ip.Y > edge1.Curr.Y)
-        {
-          ip.Y = edge1.Curr.Y;
-          //better to use the more vertical edge to derive X ...
-          if (Math.Abs(edge1.Dx) > Math.Abs(edge2.Dx)) 
-            ip.X = TopX(edge2, ip.Y);
-          else 
-            ip.X = TopX(edge1, ip.Y);
-        }
-      }
-      //------------------------------------------------------------------------------
-
-      private void ProcessEdgesAtTopOfScanbeam(cInt topY)
-      {
-        TEdge e = m_ActiveEdges;
-        while(e != null)
-        {
-          //1. process maxima, treating them as if they're 'bent' horizontal edges,
-          //   but exclude maxima with horizontal edges. nb: e can't be a horizontal.
-          bool IsMaximaEdge = IsMaxima(e, topY);
-
-          if(IsMaximaEdge)
-          {
-            TEdge eMaxPair = GetMaximaPair(e);
-            IsMaximaEdge = (eMaxPair == null || !IsHorizontal(eMaxPair));
-          }
-
-          if(IsMaximaEdge)
-          {
-            TEdge ePrev = e.PrevInAEL;
-            DoMaxima(e);
-            if( ePrev == null) e = m_ActiveEdges;
-            else e = ePrev.NextInAEL;
-          }
-          else
-          {
-            //2. promote horizontal edges, otherwise update Curr.X and Curr.Y ...
-            if (IsIntermediate(e, topY) && IsHorizontal(e.NextInLML))
-            {
-              UpdateEdgeIntoAEL(ref e);
-              if (e.OutIdx >= 0)
-                AddOutPt(e, e.Bot);
-              AddEdgeToSEL(e);
-            } 
-            else
-            {
-              e.Curr.X = TopX( e, topY );
-              e.Curr.Y = topY;
+                b1 = edge1.Bot.X - edge1.Bot.Y * edge1.Dx;
+                b2 = edge2.Bot.X - edge2.Bot.Y * edge2.Dx;
+                double q = (b2 - b1) / (edge1.Dx - edge2.Dx);
+                ip.Y = Round(q);
+                if (Math.Abs(edge1.Dx) < Math.Abs(edge2.Dx))
+                    ip.X = Round(edge1.Dx * q + b1);
+                else
+                    ip.X = Round(edge2.Dx * q + b2);
             }
 
-            if (StrictlySimple)
+            if (ip.Y < edge1.Top.Y || ip.Y < edge2.Top.Y)
             {
-              TEdge ePrev = e.PrevInAEL;
-              if ((e.OutIdx >= 0) && (e.WindDelta != 0) && ePrev != null &&
-                (ePrev.OutIdx >= 0) && (ePrev.Curr.X == e.Curr.X) &&
-                (ePrev.WindDelta != 0))
-              {
-                IntPoint ip = new IntPoint(e.Curr);
+                if (edge1.Top.Y > edge2.Top.Y)
+                    ip.Y = edge1.Top.Y;
+                else
+                    ip.Y = edge2.Top.Y;
+                if (Math.Abs(edge1.Dx) < Math.Abs(edge2.Dx))
+                    ip.X = TopX(edge1, ip.Y);
+                else
+                    ip.X = TopX(edge2, ip.Y);
+            }
+            //finally, don't allow 'ip' to be BELOW curr.Y (ie bottom of scanbeam) ...
+            if (ip.Y > edge1.Curr.Y)
+            {
+                ip.Y = edge1.Curr.Y;
+                //better to use the more vertical edge to derive X ...
+                if (Math.Abs(edge1.Dx) > Math.Abs(edge2.Dx))
+                    ip.X = TopX(edge2, ip.Y);
+                else
+                    ip.X = TopX(edge1, ip.Y);
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        private void ProcessEdgesAtTopOfScanbeam(cInt topY)
+        {
+            TEdge e = m_ActiveEdges;
+            while (e != null)
+            {
+                //1. process maxima, treating them as if they're 'bent' horizontal edges,
+                //   but exclude maxima with horizontal edges. nb: e can't be a horizontal.
+                bool IsMaximaEdge = IsMaxima(e, topY);
+
+                if (IsMaximaEdge)
+                {
+                    TEdge eMaxPair = GetMaximaPair(e);
+                    IsMaximaEdge = (eMaxPair == null || !IsHorizontal(eMaxPair));
+                }
+
+                if (IsMaximaEdge)
+                {
+                    TEdge ePrev = e.PrevInAEL;
+                    DoMaxima(e);
+                    if (ePrev == null) e = m_ActiveEdges;
+                    else e = ePrev.NextInAEL;
+                }
+                else
+                {
+                    //2. promote horizontal edges, otherwise update Curr.X and Curr.Y ...
+                    if (IsIntermediate(e, topY) && IsHorizontal(e.NextInLML))
+                    {
+                        UpdateEdgeIntoAEL(ref e);
+                        if (e.OutIdx >= 0)
+                            AddOutPt(e, e.Bot);
+                        AddEdgeToSEL(e);
+                    }
+                    else
+                    {
+                        e.Curr.X = TopX(e, topY);
+                        e.Curr.Y = topY;
+                    }
+
+                    if (StrictlySimple)
+                    {
+                        TEdge ePrev = e.PrevInAEL;
+                        if ((e.OutIdx >= 0) && (e.WindDelta != 0) && ePrev != null &&
+                          (ePrev.OutIdx >= 0) && (ePrev.Curr.X == e.Curr.X) &&
+                          (ePrev.WindDelta != 0))
+                        {
+                            IntPoint ip = new IntPoint(e.Curr);
 #if use_xyz
                 SetZ(ref ip, ePrev, e);
 #endif
-                OutPt op = AddOutPt(ePrev, ip);
-                OutPt op2 = AddOutPt(e, ip);
-                AddJoin(op, op2, ip); //StrictlySimple (type-3) join
-              }
+                            OutPt op = AddOutPt(ePrev, ip);
+                            OutPt op2 = AddOutPt(e, ip);
+                            AddJoin(op, op2, ip); //StrictlySimple (type-3) join
+                        }
+                    }
+
+                    e = e.NextInAEL;
+                }
             }
 
-            e = e.NextInAEL;
-          }
+            //3. Process horizontals at the Top of the scanbeam ...
+            ProcessHorizontals(true);
+
+            //4. Promote intermediate vertices ...
+            e = m_ActiveEdges;
+            while (e != null)
+            {
+                if (IsIntermediate(e, topY))
+                {
+                    OutPt op = null;
+                    if (e.OutIdx >= 0)
+                        op = AddOutPt(e, e.Top);
+                    UpdateEdgeIntoAEL(ref e);
+
+                    //if output polygons share an edge, they'll need joining later ...
+                    TEdge ePrev = e.PrevInAEL;
+                    TEdge eNext = e.NextInAEL;
+                    if (ePrev != null && ePrev.Curr.X == e.Bot.X &&
+                      ePrev.Curr.Y == e.Bot.Y && op != null &&
+                      ePrev.OutIdx >= 0 && ePrev.Curr.Y > ePrev.Top.Y &&
+                      SlopesEqual(e, ePrev, MUseFullRange) &&
+                      (e.WindDelta != 0) && (ePrev.WindDelta != 0))
+                    {
+                        OutPt op2 = AddOutPt(ePrev, e.Bot);
+                        AddJoin(op, op2, e.Top);
+                    }
+                    else if (eNext != null && eNext.Curr.X == e.Bot.X &&
+                      eNext.Curr.Y == e.Bot.Y && op != null &&
+                      eNext.OutIdx >= 0 && eNext.Curr.Y > eNext.Top.Y &&
+                      SlopesEqual(e, eNext, MUseFullRange) &&
+                      (e.WindDelta != 0) && (eNext.WindDelta != 0))
+                    {
+                        OutPt op2 = AddOutPt(eNext, e.Bot);
+                        AddJoin(op, op2, e.Top);
+                    }
+                }
+                e = e.NextInAEL;
+            }
         }
+        //------------------------------------------------------------------------------
 
-        //3. Process horizontals at the Top of the scanbeam ...
-        ProcessHorizontals(true);
-
-        //4. Promote intermediate vertices ...
-        e = m_ActiveEdges;
-        while (e != null)
+        private void DoMaxima(TEdge e)
         {
-          if(IsIntermediate(e, topY))
-          {
-            OutPt op = null;
-            if( e.OutIdx >= 0 ) 
-              op = AddOutPt(e, e.Top);
-            UpdateEdgeIntoAEL(ref e);
+            TEdge eMaxPair = GetMaximaPair(e);
+            if (eMaxPair == null)
+            {
+                if (e.OutIdx >= 0)
+                    AddOutPt(e, e.Top);
+                DeleteFromAEL(e);
+                return;
+            }
 
-            //if output polygons share an edge, they'll need joining later ...
-            TEdge ePrev = e.PrevInAEL;
             TEdge eNext = e.NextInAEL;
-            if (ePrev != null && ePrev.Curr.X == e.Bot.X &&
-              ePrev.Curr.Y == e.Bot.Y && op != null &&
-              ePrev.OutIdx >= 0 && ePrev.Curr.Y > ePrev.Top.Y &&
-              SlopesEqual(e, ePrev, MUseFullRange) &&
-              (e.WindDelta != 0) && (ePrev.WindDelta != 0))
+            while (eNext != null && eNext != eMaxPair)
             {
-              OutPt op2 = AddOutPt(ePrev, e.Bot);
-              AddJoin(op, op2, e.Top);
+                IntersectEdges(e, eNext, e.Top);
+                SwapPositionsInAEL(e, eNext);
+                eNext = e.NextInAEL;
             }
-            else if (eNext != null && eNext.Curr.X == e.Bot.X &&
-              eNext.Curr.Y == e.Bot.Y && op != null &&
-              eNext.OutIdx >= 0 && eNext.Curr.Y > eNext.Top.Y &&
-              SlopesEqual(e, eNext, MUseFullRange) &&
-              (e.WindDelta != 0) && (eNext.WindDelta != 0))
+
+            if (e.OutIdx == Unassigned && eMaxPair.OutIdx == Unassigned)
             {
-              OutPt op2 = AddOutPt(eNext, e.Bot);
-              AddJoin(op, op2, e.Top);
+                DeleteFromAEL(e);
+                DeleteFromAEL(eMaxPair);
             }
-          }
-          e = e.NextInAEL;
-        }
-      }
-      //------------------------------------------------------------------------------
-
-      private void DoMaxima(TEdge e)
-      {
-        TEdge eMaxPair = GetMaximaPair(e);
-        if (eMaxPair == null)
-        {
-          if (e.OutIdx >= 0)
-            AddOutPt(e, e.Top);
-          DeleteFromAEL(e);
-          return;
-        }
-
-        TEdge eNext = e.NextInAEL;
-        while(eNext != null && eNext != eMaxPair)
-        {
-          IntersectEdges(e, eNext, e.Top);
-          SwapPositionsInAEL(e, eNext);
-          eNext = e.NextInAEL;
-        }
-
-        if(e.OutIdx == Unassigned && eMaxPair.OutIdx == Unassigned)
-        {
-          DeleteFromAEL(e);
-          DeleteFromAEL(eMaxPair);
-        }
-        else if( e.OutIdx >= 0 && eMaxPair.OutIdx >= 0 )
-        {
-          if (e.OutIdx >= 0) AddLocalMaxPoly(e, eMaxPair, e.Top);
-          DeleteFromAEL(e);
-          DeleteFromAEL(eMaxPair);
-        }
+            else if (e.OutIdx >= 0 && eMaxPair.OutIdx >= 0)
+            {
+                if (e.OutIdx >= 0) AddLocalMaxPoly(e, eMaxPair, e.Top);
+                DeleteFromAEL(e);
+                DeleteFromAEL(eMaxPair);
+            }
 #if use_lines
         else if (e.WindDelta == 0)
         {
@@ -3197,1557 +3211,1563 @@ namespace TVGL.Boolean_Operations.Clipper
           DeleteFromAEL(eMaxPair);
         } 
 #endif
-        else throw new ClipperException("DoMaxima error");
-      }
-      //------------------------------------------------------------------------------
-
-      internal static void ReversePaths(Paths polys)
-      {
-        foreach (var poly in polys) { poly.Reverse(); }
-      }
-      //------------------------------------------------------------------------------
-
-      internal static bool Orientation(Path poly)
-      {
-          return Area(poly) >= 0;
-      }
-      //------------------------------------------------------------------------------
-
-      private int PointCount(OutPt pts)
-      {
-          if (pts == null) return 0;
-          int result = 0;
-          OutPt p = pts;
-          do
-          {
-              result++;
-              p = p.Next;
-          }
-          while (p != pts);
-          return result;
-      }
-      //------------------------------------------------------------------------------
-
-      private void BuildResult(Paths polyg)
-      {
-          polyg.Clear();
-          polyg.Capacity = m_PolyOuts.Count;
-          for (int i = 0; i < m_PolyOuts.Count; i++)
-          {
-              OutRec outRec = m_PolyOuts[i];
-              if (outRec.Pts == null) continue;
-              OutPt p = outRec.Pts.Prev;
-              int cnt = PointCount(p);
-              if (cnt < 2) continue;
-              Path pg = new Path(cnt);
-              for (int j = 0; j < cnt; j++)
-              {
-                  pg.Add(p.Pt);
-                  p = p.Prev;
-              }
-              polyg.Add(pg);
-          }
-      }
-      //------------------------------------------------------------------------------
-
-      private void BuildResult2(PolyTree polytree)
-      {
-          polytree.Clear();
-
-          //add each output polygon/contour to polytree ...
-          polytree.MAllPolys.Capacity = m_PolyOuts.Count;
-          for (int i = 0; i < m_PolyOuts.Count; i++)
-          {
-              OutRec outRec = m_PolyOuts[i];
-              int cnt = PointCount(outRec.Pts);
-              if ((outRec.IsOpen && cnt < 2) || 
-                (!outRec.IsOpen && cnt < 3)) continue;
-              FixHoleLinkage(outRec);
-              PolyNode pn = new PolyNode();
-              polytree.MAllPolys.Add(pn);
-              outRec.PolyNode = pn;
-              pn.MPolygon.Capacity = cnt;
-              OutPt op = outRec.Pts.Prev;
-              for (int j = 0; j < cnt; j++)
-              {
-                  pn.MPolygon.Add(op.Pt);
-                  op = op.Prev;
-              }
-          }
-
-          //fixup PolyNode links etc ...
-          polytree.MChilds.Capacity = m_PolyOuts.Count;
-          for (int i = 0; i < m_PolyOuts.Count; i++)
-          {
-              OutRec outRec = m_PolyOuts[i];
-              if (outRec.PolyNode == null) continue;
-              else if (outRec.IsOpen)
-              {
-                outRec.PolyNode.IsOpen = true;
-                polytree.AddChild(outRec.PolyNode);
-              }
-              else if (outRec.FirstLeft != null && 
-                outRec.FirstLeft.PolyNode != null)
-                  outRec.FirstLeft.PolyNode.AddChild(outRec.PolyNode);
-              else
-                polytree.AddChild(outRec.PolyNode);
-          }
-      }
-      //------------------------------------------------------------------------------
-
-      private void FixupOutPolygon(OutRec outRec)
-      {
-          //FixupOutPolygon() - removes duplicate points and simplifies consecutive
-          //parallel edges by removing the middle vertex.
-          OutPt lastOK = null;
-          outRec.BottomPt = null;
-          OutPt pp = outRec.Pts;
-          for (;;)
-          {
-              if (pp.Prev == pp || pp.Prev == pp.Next)
-              {
-                  outRec.Pts = null;
-                  return;
-              }
-              //test for duplicate points and collinear edges ...
-              if ((pp.Pt == pp.Next.Pt) || (pp.Pt == pp.Prev.Pt) ||
-                (SlopesEqual(pp.Prev.Pt, pp.Pt, pp.Next.Pt, MUseFullRange) &&
-                (!PreserveCollinear || !Pt2IsBetweenPt1AndPt3(pp.Prev.Pt, pp.Pt, pp.Next.Pt))))
-              {
-                  lastOK = null;
-                  pp.Prev.Next = pp.Next;
-                  pp.Next.Prev = pp.Prev;
-                  pp = pp.Prev;
-              }
-              else if (pp == lastOK) break;
-              else
-              {
-                  if (lastOK == null) lastOK = pp;
-                  pp = pp.Next;
-              }
-          }
-          outRec.Pts = pp;
-      }
-      //------------------------------------------------------------------------------
-
-      OutPt DupOutPt(OutPt outPt, bool InsertAfter)
-      {
-        OutPt result = new OutPt();
-        result.Pt = outPt.Pt;
-        result.Idx = outPt.Idx;
-        if (InsertAfter)
-        {
-          result.Next = outPt.Next;
-          result.Prev = outPt;
-          outPt.Next.Prev = result;
-          outPt.Next = result;
-        } 
-        else
-        {
-          result.Prev = outPt.Prev;
-          result.Next = outPt;
-          outPt.Prev.Next = result;
-          outPt.Prev = result;
+            else throw new ClipperException("DoMaxima error");
         }
-        return result;
-      }
-      //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-      bool GetOverlap(cInt a1, cInt a2, cInt b1, cInt b2, out cInt Left, out cInt Right)
-      {
-        if (a1 < a2)
+        internal static void ReversePaths(Paths polys)
         {
-          if (b1 < b2) {Left = Math.Max(a1,b1); Right = Math.Min(a2,b2);}
-          else {Left = Math.Max(a1,b2); Right = Math.Min(a2,b1);}
-        } 
-        else
-        {
-          if (b1 < b2) {Left = Math.Max(a2,b1); Right = Math.Min(a1,b2);}
-          else { Left = Math.Max(a2, b2); Right = Math.Min(a1, b1); }
+            foreach (var poly in polys) { poly.Reverse(); }
         }
-        return Left < Right;
-      }
-      //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-      bool JoinHorz(OutPt op1, OutPt op1b, OutPt op2, OutPt op2b, 
-        IntPoint Pt, bool DiscardLeft)
-      {
-        Direction Dir1 = (op1.Pt.X > op1b.Pt.X ? 
-          Direction.dRightToLeft : Direction.dLeftToRight);
-        Direction Dir2 = (op2.Pt.X > op2b.Pt.X ?
-          Direction.dRightToLeft : Direction.dLeftToRight);
-        if (Dir1 == Dir2) return false;
-
-        //When DiscardLeft, we want Op1b to be on the Left of Op1, otherwise we
-        //want Op1b to be on the Right. (And likewise with Op2 and Op2b.)
-        //So, to facilitate this while inserting Op1b and Op2b ...
-        //when DiscardLeft, make sure we're AT or RIGHT of Pt before adding Op1b,
-        //otherwise make sure we're AT or LEFT of Pt. (Likewise with Op2b.)
-        if (Dir1 == Direction.dLeftToRight) 
+        internal static bool Orientation(Path poly)
         {
-          while (op1.Next.Pt.X <= Pt.X && 
-            op1.Next.Pt.X >= op1.Pt.X && op1.Next.Pt.Y == Pt.Y)  
-              op1 = op1.Next;
-          if (DiscardLeft && (op1.Pt.X != Pt.X)) op1 = op1.Next;
-          op1b = DupOutPt(op1, !DiscardLeft);
-          if (op1b.Pt != Pt) 
-          {
-            op1 = op1b;
-            op1.Pt = Pt;
-            op1b = DupOutPt(op1, !DiscardLeft);
-          }
-        } 
-        else
-        {
-          while (op1.Next.Pt.X >= Pt.X && 
-            op1.Next.Pt.X <= op1.Pt.X && op1.Next.Pt.Y == Pt.Y) 
-              op1 = op1.Next;
-          if (!DiscardLeft && (op1.Pt.X != Pt.X)) op1 = op1.Next;
-          op1b = DupOutPt(op1, DiscardLeft);
-          if (op1b.Pt != Pt)
-          {
-            op1 = op1b;
-            op1.Pt = Pt;
-            op1b = DupOutPt(op1, DiscardLeft);
-          }
+            return Area(poly) >= 0;
         }
+        //------------------------------------------------------------------------------
 
-        if (Dir2 == Direction.dLeftToRight)
+        private int PointCount(OutPt pts)
         {
-          while (op2.Next.Pt.X <= Pt.X && 
-            op2.Next.Pt.X >= op2.Pt.X && op2.Next.Pt.Y == Pt.Y)
-              op2 = op2.Next;
-          if (DiscardLeft && (op2.Pt.X != Pt.X)) op2 = op2.Next;
-          op2b = DupOutPt(op2, !DiscardLeft);
-          if (op2b.Pt != Pt)
-          {
-            op2 = op2b;
-            op2.Pt = Pt;
-            op2b = DupOutPt(op2, !DiscardLeft);
-          };
-        } else
-        {
-          while (op2.Next.Pt.X >= Pt.X && 
-            op2.Next.Pt.X <= op2.Pt.X && op2.Next.Pt.Y == Pt.Y) 
-              op2 = op2.Next;
-          if (!DiscardLeft && (op2.Pt.X != Pt.X)) op2 = op2.Next;
-          op2b = DupOutPt(op2, DiscardLeft);
-          if (op2b.Pt != Pt)
-          {
-            op2 = op2b;
-            op2.Pt = Pt;
-            op2b = DupOutPt(op2, DiscardLeft);
-          };
-        };
-
-        if ((Dir1 == Direction.dLeftToRight) == DiscardLeft)
-        {
-          op1.Prev = op2;
-          op2.Next = op1;
-          op1b.Next = op2b;
-          op2b.Prev = op1b;
-        }
-        else
-        {
-          op1.Next = op2;
-          op2.Prev = op1;
-          op1b.Prev = op2b;
-          op2b.Next = op1b;
-        }
-        return true;
-      }
-      //------------------------------------------------------------------------------
-
-      private bool JoinPoints(Join j, OutRec outRec1, OutRec outRec2)
-      {
-        OutPt op1 = j.OutPt1, op1b;
-        OutPt op2 = j.OutPt2, op2b;
-
-        //There are 3 kinds of joins for output polygons ...
-        //1. Horizontal joins where Join.OutPt1 & Join.OutPt2 are a vertices anywhere
-        //along (horizontal) collinear edges (& Join.OffPt is on the same horizontal).
-        //2. Non-horizontal joins where Join.OutPt1 & Join.OutPt2 are at the same
-        //location at the Bottom of the overlapping segment (& Join.OffPt is above).
-        //3. StrictlySimple joins where edges touch but are not collinear and where
-        //Join.OutPt1, Join.OutPt2 & Join.OffPt all share the same point.
-        bool isHorizontal = (j.OutPt1.Pt.Y == j.OffPt.Y);
-
-        if (isHorizontal && (j.OffPt == j.OutPt1.Pt) && (j.OffPt == j.OutPt2.Pt))
-        {          
-          //Strictly Simple join ...
-          if (outRec1 != outRec2) return false;
-          op1b = j.OutPt1.Next;
-          while (op1b != op1 && (op1b.Pt == j.OffPt)) 
-            op1b = op1b.Next;
-          bool reverse1 = (op1b.Pt.Y > j.OffPt.Y);
-          op2b = j.OutPt2.Next;
-          while (op2b != op2 && (op2b.Pt == j.OffPt)) 
-            op2b = op2b.Next;
-          bool reverse2 = (op2b.Pt.Y > j.OffPt.Y);
-          if (reverse1 == reverse2) return false;
-          if (reverse1)
-          {
-            op1b = DupOutPt(op1, false);
-            op2b = DupOutPt(op2, true);
-            op1.Prev = op2;
-            op2.Next = op1;
-            op1b.Next = op2b;
-            op2b.Prev = op1b;
-            j.OutPt1 = op1;
-            j.OutPt2 = op1b;
-            return true;
-          } else
-          {
-            op1b = DupOutPt(op1, true);
-            op2b = DupOutPt(op2, false);
-            op1.Next = op2;
-            op2.Prev = op1;
-            op1b.Prev = op2b;
-            op2b.Next = op1b;
-            j.OutPt1 = op1;
-            j.OutPt2 = op1b;
-            return true;
-          }
-        } 
-        else if (isHorizontal)
-        {
-          //treat horizontal joins differently to non-horizontal joins since with
-          //them we're not yet sure where the overlapping is. OutPt1.Pt & OutPt2.Pt
-          //may be anywhere along the horizontal edge.
-          op1b = op1;
-          while (op1.Prev.Pt.Y == op1.Pt.Y && op1.Prev != op1b && op1.Prev != op2)
-            op1 = op1.Prev;
-          while (op1b.Next.Pt.Y == op1b.Pt.Y && op1b.Next != op1 && op1b.Next != op2)
-            op1b = op1b.Next;
-          if (op1b.Next == op1 || op1b.Next == op2) return false; //a flat 'polygon'
-
-          op2b = op2;
-          while (op2.Prev.Pt.Y == op2.Pt.Y && op2.Prev != op2b && op2.Prev != op1b)
-            op2 = op2.Prev;
-          while (op2b.Next.Pt.Y == op2b.Pt.Y && op2b.Next != op2 && op2b.Next != op1)
-            op2b = op2b.Next;
-          if (op2b.Next == op2 || op2b.Next == op1) return false; //a flat 'polygon'
-
-          cInt Left, Right;
-          //Op1 -. Op1b & Op2 -. Op2b are the extremites of the horizontal edges
-          if (!GetOverlap(op1.Pt.X, op1b.Pt.X, op2.Pt.X, op2b.Pt.X, out Left, out Right))
-            return false;
-
-          //DiscardLeftSide: when overlapping edges are joined, a spike will created
-          //which needs to be cleaned up. However, we don't want Op1 or Op2 caught up
-          //on the discard Side as either may still be needed for other joins ...
-          IntPoint Pt;
-          bool DiscardLeftSide;
-          if (op1.Pt.X >= Left && op1.Pt.X <= Right) 
-          {
-            Pt = op1.Pt; DiscardLeftSide = (op1.Pt.X > op1b.Pt.X);
-          } 
-          else if (op2.Pt.X >= Left&& op2.Pt.X <= Right) 
-          {
-            Pt = op2.Pt; DiscardLeftSide = (op2.Pt.X > op2b.Pt.X);
-          } 
-          else if (op1b.Pt.X >= Left && op1b.Pt.X <= Right)
-          {
-            Pt = op1b.Pt; DiscardLeftSide = op1b.Pt.X > op1.Pt.X;
-          } 
-          else
-          {
-            Pt = op2b.Pt; DiscardLeftSide = (op2b.Pt.X > op2.Pt.X);
-          }
-          j.OutPt1 = op1;
-          j.OutPt2 = op2;
-          return JoinHorz(op1, op1b, op2, op2b, Pt, DiscardLeftSide);
-        } else
-        {
-          //nb: For non-horizontal joins ...
-          //    1. Jr.OutPt1.Pt.Y == Jr.OutPt2.Pt.Y
-          //    2. Jr.OutPt1.Pt > Jr.OffPt.Y
-
-          //make sure the polygons are correctly oriented ...
-          op1b = op1.Next;
-          while ((op1b.Pt == op1.Pt) && (op1b != op1)) op1b = op1b.Next;
-          bool Reverse1 = ((op1b.Pt.Y > op1.Pt.Y) ||
-            !SlopesEqual(op1.Pt, op1b.Pt, j.OffPt, MUseFullRange));
-          if (Reverse1)
-          {
-            op1b = op1.Prev;
-            while ((op1b.Pt == op1.Pt) && (op1b != op1)) op1b = op1b.Prev;
-            if ((op1b.Pt.Y > op1.Pt.Y) ||
-              !SlopesEqual(op1.Pt, op1b.Pt, j.OffPt, MUseFullRange)) return false;
-          };
-          op2b = op2.Next;
-          while ((op2b.Pt == op2.Pt) && (op2b != op2)) op2b = op2b.Next;
-          bool Reverse2 = ((op2b.Pt.Y > op2.Pt.Y) ||
-            !SlopesEqual(op2.Pt, op2b.Pt, j.OffPt, MUseFullRange));
-          if (Reverse2)
-          {
-            op2b = op2.Prev;
-            while ((op2b.Pt == op2.Pt) && (op2b != op2)) op2b = op2b.Prev;
-            if ((op2b.Pt.Y > op2.Pt.Y) ||
-              !SlopesEqual(op2.Pt, op2b.Pt, j.OffPt, MUseFullRange)) return false;
-          }
-
-          if ((op1b == op1) || (op2b == op2) || (op1b == op2b) ||
-            ((outRec1 == outRec2) && (Reverse1 == Reverse2))) return false;
-
-          if (Reverse1)
-          {
-            op1b = DupOutPt(op1, false);
-            op2b = DupOutPt(op2, true);
-            op1.Prev = op2;
-            op2.Next = op1;
-            op1b.Next = op2b;
-            op2b.Prev = op1b;
-            j.OutPt1 = op1;
-            j.OutPt2 = op1b;
-            return true;
-          } else
-          {
-            op1b = DupOutPt(op1, true);
-            op2b = DupOutPt(op2, false);
-            op1.Next = op2;
-            op2.Prev = op1;
-            op1b.Prev = op2b;
-            op2b.Next = op1b;
-            j.OutPt1 = op1;
-            j.OutPt2 = op1b;
-            return true;
-          }
-        }
-      }
-      //----------------------------------------------------------------------
-
-      internal static int PointInPolygon(IntPoint pt, Path path)
-      {
-        //returns 0 if false, +1 if true, -1 if pt ON polygon boundary
-        //See "The Point in Polygon Problem for Arbitrary Polygons" by Hormann & Agathos
-        //http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.88.5498&rep=rep1&type=pdf
-        int result = 0, cnt = path.Count;
-        if (cnt < 3) return 0;
-        IntPoint ip = path[0];
-        for (int i = 1; i <= cnt; ++i)
-        {
-          IntPoint ipNext = (i == cnt ? path[0] : path[i]);
-          if (ipNext.Y == pt.Y)
-          {
-            if ((ipNext.X == pt.X) || (ip.Y == pt.Y &&
-              ((ipNext.X > pt.X) == (ip.X < pt.X)))) return -1;
-          }
-          if ((ip.Y < pt.Y) != (ipNext.Y < pt.Y))
-          {
-            if (ip.X >= pt.X)
+            if (pts == null) return 0;
+            int result = 0;
+            OutPt p = pts;
+            do
             {
-              if (ipNext.X > pt.X) result = 1 - result;
-              else
-              {
-                double d = (double)(ip.X - pt.X) * (ipNext.Y - pt.Y) -
-                  (double)(ipNext.X - pt.X) * (ip.Y - pt.Y);
-                if (d == 0) return -1;
-                else if ((d > 0) == (ipNext.Y > ip.Y)) result = 1 - result;
-              }
+                result++;
+                p = p.Next;
             }
-            else
-            {
-              if (ipNext.X > pt.X)
-              {
-                double d = (double)(ip.X - pt.X) * (ipNext.Y - pt.Y) -
-                  (double)(ipNext.X - pt.X) * (ip.Y - pt.Y);
-                if (d == 0) return -1;
-                else if ((d > 0) == (ipNext.Y > ip.Y)) result = 1 - result;
-              }
-            }
-          }
-          ip = ipNext;
+            while (p != pts);
+            return result;
         }
-        return result;
-      }
-      //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-      private static int PointInPolygon(IntPoint pt, OutPt op)
-      {
-        //returns 0 if false, +1 if true, -1 if pt ON polygon boundary
-        //See "The Point in Polygon Problem for Arbitrary Polygons" by Hormann & Agathos
-        //http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.88.5498&rep=rep1&type=pdf
-        int result = 0;
-        OutPt startOp = op;
-        cInt ptx = pt.X, pty = pt.Y;
-        cInt poly0x = op.Pt.X, poly0y = op.Pt.Y;
-        do
+        private void BuildResult(Paths polyg)
         {
-          op = op.Next;
-          cInt poly1x = op.Pt.X, poly1y = op.Pt.Y;
-
-          if (poly1y == pty)
-          {
-            if ((poly1x == ptx) || (poly0y == pty &&
-              ((poly1x > ptx) == (poly0x < ptx)))) return -1;
-          }
-          if ((poly0y < pty) != (poly1y < pty))
-          {
-            if (poly0x >= ptx)
+            polyg.Clear();
+            polyg.Capacity = m_PolyOuts.Count;
+            for (int i = 0; i < m_PolyOuts.Count; i++)
             {
-              if (poly1x > ptx) result = 1 - result;
-              else
-              {
-                double d = (double)(poly0x - ptx) * (poly1y - pty) -
-                  (double)(poly1x - ptx) * (poly0y - pty);
-                if (d == 0) return -1;
-                if ((d > 0) == (poly1y > poly0y)) result = 1 - result;
-              }
-            }
-            else
-            {
-              if (poly1x > ptx)
-              {
-                double d = (double)(poly0x - ptx) * (poly1y - pty) -
-                  (double)(poly1x - ptx) * (poly0y - pty);
-                if (d == 0) return -1;
-                if ((d > 0) == (poly1y > poly0y)) result = 1 - result;
-              }
-            }
-          }
-          poly0x = poly1x; poly0y = poly1y;
-        } while (startOp != op);
-        return result;
-      }
-      //------------------------------------------------------------------------------
-
-      private static bool Poly2ContainsPoly1(OutPt outPt1, OutPt outPt2)
-      {
-        OutPt op = outPt1;
-        do
-        {
-          //nb: PointInPolygon returns 0 if false, +1 if true, -1 if pt on polygon
-          int res = PointInPolygon(op.Pt, outPt2);
-          if (res >= 0) return res > 0;
-          op = op.Next;
-        }
-        while (op != outPt1);
-        return true;
-      }
-      //----------------------------------------------------------------------
-
-      private void FixupFirstLefts1(OutRec OldOutRec, OutRec NewOutRec)
-      { 
-          for (int i = 0; i < m_PolyOuts.Count; i++)
-          {
-              OutRec outRec = m_PolyOuts[i];
-              if (outRec.Pts == null || outRec.FirstLeft == null) continue;
-              OutRec firstLeft = ParseFirstLeft(outRec.FirstLeft);
-              if (firstLeft == OldOutRec)
-              {
-                  if (Poly2ContainsPoly1(outRec.Pts, NewOutRec.Pts))
-                      outRec.FirstLeft = NewOutRec;
-              }
-          }
-      }
-      //----------------------------------------------------------------------
-
-      private void FixupFirstLefts2(OutRec OldOutRec, OutRec NewOutRec)
-      { 
-          foreach (OutRec outRec in m_PolyOuts)
-              if (outRec.FirstLeft == OldOutRec) outRec.FirstLeft = NewOutRec;
-      }
-      //----------------------------------------------------------------------
-
-      private static OutRec ParseFirstLeft(OutRec FirstLeft)
-      {
-        while (FirstLeft != null && FirstLeft.Pts == null) 
-          FirstLeft = FirstLeft.FirstLeft;
-        return FirstLeft;
-      }
-      //------------------------------------------------------------------------------
-
-    private void JoinCommonEdges()
-      {
-        for (int i = 0; i < m_Joins.Count; i++)
-        {
-          Join join = m_Joins[i];
-
-          OutRec outRec1 = GetOutRec(join.OutPt1.Idx);
-          OutRec outRec2 = GetOutRec(join.OutPt2.Idx);
-
-          if (outRec1.Pts == null || outRec2.Pts == null) continue;
-
-          //get the polygon fragment with the correct hole state (FirstLeft)
-          //before calling JoinPoints() ...
-          OutRec holeStateRec;
-          if (outRec1 == outRec2) holeStateRec = outRec1;
-          else if (Param1RightOfParam2(outRec1, outRec2)) holeStateRec = outRec2;
-          else if (Param1RightOfParam2(outRec2, outRec1)) holeStateRec = outRec1;
-          else holeStateRec = GetLowermostRec(outRec1, outRec2);
-
-          if (!JoinPoints(join, outRec1, outRec2)) continue;
-
-          if (outRec1 == outRec2)
-          {
-            //instead of joining two polygons, we've just created a new one by
-            //splitting one polygon into two.
-            outRec1.Pts = join.OutPt1;
-            outRec1.BottomPt = null;
-            outRec2 = CreateOutRec();
-            outRec2.Pts = join.OutPt2;
-
-            //update all OutRec2.Pts Idx's ...
-            UpdateOutPtIdxs(outRec2);
-
-            //We now need to check every OutRec.FirstLeft pointer. If it points
-            //to OutRec1 it may need to point to OutRec2 instead ...
-            if (m_UsingPolyTree)
-              for (int j = 0; j < m_PolyOuts.Count - 1; j++)
-              {
-                OutRec oRec = m_PolyOuts[j];
-                if (oRec.Pts == null || ParseFirstLeft(oRec.FirstLeft) != outRec1 ||
-                  oRec.IsHole == outRec1.IsHole) continue;
-                if (Poly2ContainsPoly1(oRec.Pts, join.OutPt2))
-                  oRec.FirstLeft = outRec2;
-              }
-
-            if (Poly2ContainsPoly1(outRec2.Pts, outRec1.Pts))
-            {
-              //outRec2 is contained by outRec1 ...
-              outRec2.IsHole = !outRec1.IsHole;
-              outRec2.FirstLeft = outRec1;
-
-              //fixup FirstLeft pointers that may need reassigning to OutRec1
-              if (m_UsingPolyTree) FixupFirstLefts2(outRec2, outRec1);
-
-              if ((outRec2.IsHole ^ ReverseSolution) == (Area(outRec2) > 0))
-                ReversePolyPtLinks(outRec2.Pts);
-
-            }
-            else if (Poly2ContainsPoly1(outRec1.Pts, outRec2.Pts))
-            {
-              //outRec1 is contained by outRec2 ...
-              outRec2.IsHole = outRec1.IsHole;
-              outRec1.IsHole = !outRec2.IsHole;
-              outRec2.FirstLeft = outRec1.FirstLeft;
-              outRec1.FirstLeft = outRec2;
-
-              //fixup FirstLeft pointers that may need reassigning to OutRec1
-              if (m_UsingPolyTree) FixupFirstLefts2(outRec1, outRec2);
-
-              if ((outRec1.IsHole ^ ReverseSolution) == (Area(outRec1) > 0))
-                ReversePolyPtLinks(outRec1.Pts);
-            }
-            else
-            {
-              //the 2 polygons are completely separate ...
-              outRec2.IsHole = outRec1.IsHole;
-              outRec2.FirstLeft = outRec1.FirstLeft;
-
-              //fixup FirstLeft pointers that may need reassigning to OutRec2
-              if (m_UsingPolyTree) FixupFirstLefts1(outRec1, outRec2);
-            }
-     
-          } else
-          {
-            //joined 2 polygons together ...
-
-            outRec2.Pts = null;
-            outRec2.BottomPt = null;
-            outRec2.Idx = outRec1.Idx;
-
-            outRec1.IsHole = holeStateRec.IsHole;
-            if (holeStateRec == outRec2) 
-              outRec1.FirstLeft = outRec2.FirstLeft;
-            outRec2.FirstLeft = outRec1;
-
-            //fixup FirstLeft pointers that may need reassigning to OutRec1
-            if (m_UsingPolyTree) FixupFirstLefts2(outRec2, outRec1);
-          }
-        }
-      }
-      //------------------------------------------------------------------------------
-
-      private void UpdateOutPtIdxs(OutRec outrec)
-      {  
-        OutPt op = outrec.Pts;
-        do
-        {
-          op.Idx = outrec.Idx;
-          op = op.Prev;
-        }
-        while(op != outrec.Pts);
-      }
-      //------------------------------------------------------------------------------
-
-      private void DoSimplePolygons()
-      {
-        int i = 0;
-        while (i < m_PolyOuts.Count) 
-        {
-          OutRec outrec = m_PolyOuts[i++];
-          OutPt op = outrec.Pts;
-          if (op == null || outrec.IsOpen) continue;
-          do //for each Pt in Polygon until duplicate found do ...
-          {
-            OutPt op2 = op.Next;
-            while (op2 != outrec.Pts) 
-            {
-              if ((op.Pt == op2.Pt) && op2.Next != op && op2.Prev != op) 
-              {
-                //split the polygon into two ...
-                OutPt op3 = op.Prev;
-                OutPt op4 = op2.Prev;
-                op.Prev = op4;
-                op4.Next = op;
-                op2.Prev = op3;
-                op3.Next = op2;
-
-                outrec.Pts = op;
-                OutRec outrec2 = CreateOutRec();
-                outrec2.Pts = op2;
-                UpdateOutPtIdxs(outrec2);
-                if (Poly2ContainsPoly1(outrec2.Pts, outrec.Pts))
+                OutRec outRec = m_PolyOuts[i];
+                if (outRec.Pts == null) continue;
+                OutPt p = outRec.Pts.Prev;
+                int cnt = PointCount(p);
+                if (cnt < 2) continue;
+                Path pg = new Path(cnt);
+                for (int j = 0; j < cnt; j++)
                 {
-                  //OutRec2 is contained by OutRec1 ...
-                  outrec2.IsHole = !outrec.IsHole;
-                  outrec2.FirstLeft = outrec;
-                  if (m_UsingPolyTree) FixupFirstLefts2(outrec2, outrec);
+                    pg.Add(p.Pt);
+                    p = p.Prev;
+                }
+                polyg.Add(pg);
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        private void BuildResult2(PolyTree polytree)
+        {
+            polytree.Clear();
+
+            //add each output polygon/contour to polytree ...
+            polytree.MAllPolys.Capacity = m_PolyOuts.Count;
+            for (int i = 0; i < m_PolyOuts.Count; i++)
+            {
+                OutRec outRec = m_PolyOuts[i];
+                int cnt = PointCount(outRec.Pts);
+                if ((outRec.IsOpen && cnt < 2) ||
+                  (!outRec.IsOpen && cnt < 3)) continue;
+                FixHoleLinkage(outRec);
+                PolyNode pn = new PolyNode();
+                polytree.MAllPolys.Add(pn);
+                outRec.PolyNode = pn;
+                pn.MPolygon.Capacity = cnt;
+                OutPt op = outRec.Pts.Prev;
+                for (int j = 0; j < cnt; j++)
+                {
+                    pn.MPolygon.Add(op.Pt);
+                    op = op.Prev;
+                }
+            }
+
+            //fixup PolyNode links etc ...
+            polytree.MChilds.Capacity = m_PolyOuts.Count;
+            for (int i = 0; i < m_PolyOuts.Count; i++)
+            {
+                OutRec outRec = m_PolyOuts[i];
+                if (outRec.PolyNode == null) continue;
+                else if (outRec.IsOpen)
+                {
+                    outRec.PolyNode.IsOpen = true;
+                    polytree.AddChild(outRec.PolyNode);
+                }
+                else if (outRec.FirstLeft != null &&
+                  outRec.FirstLeft.PolyNode != null)
+                    outRec.FirstLeft.PolyNode.AddChild(outRec.PolyNode);
+                else
+                    polytree.AddChild(outRec.PolyNode);
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        private void FixupOutPolygon(OutRec outRec)
+        {
+            //FixupOutPolygon() - removes duplicate points and simplifies consecutive
+            //parallel edges by removing the middle vertex.
+            OutPt lastOK = null;
+            outRec.BottomPt = null;
+            OutPt pp = outRec.Pts;
+            for (;;)
+            {
+                if (pp.Prev == pp || pp.Prev == pp.Next)
+                {
+                    outRec.Pts = null;
+                    return;
+                }
+                //test for duplicate points and collinear edges ...
+                if ((pp.Pt == pp.Next.Pt) || (pp.Pt == pp.Prev.Pt) ||
+                  (SlopesEqual(pp.Prev.Pt, pp.Pt, pp.Next.Pt, MUseFullRange) &&
+                  (!PreserveCollinear || !Pt2IsBetweenPt1AndPt3(pp.Prev.Pt, pp.Pt, pp.Next.Pt))))
+                {
+                    lastOK = null;
+                    pp.Prev.Next = pp.Next;
+                    pp.Next.Prev = pp.Prev;
+                    pp = pp.Prev;
+                }
+                else if (pp == lastOK) break;
+                else
+                {
+                    if (lastOK == null) lastOK = pp;
+                    pp = pp.Next;
+                }
+            }
+            outRec.Pts = pp;
+        }
+        //------------------------------------------------------------------------------
+
+        OutPt DupOutPt(OutPt outPt, bool InsertAfter)
+        {
+            OutPt result = new OutPt();
+            result.Pt = outPt.Pt;
+            result.Idx = outPt.Idx;
+            if (InsertAfter)
+            {
+                result.Next = outPt.Next;
+                result.Prev = outPt;
+                outPt.Next.Prev = result;
+                outPt.Next = result;
+            }
+            else
+            {
+                result.Prev = outPt.Prev;
+                result.Next = outPt;
+                outPt.Prev.Next = result;
+                outPt.Prev = result;
+            }
+            return result;
+        }
+        //------------------------------------------------------------------------------
+
+        bool GetOverlap(cInt a1, cInt a2, cInt b1, cInt b2, out cInt Left, out cInt Right)
+        {
+            if (a1 < a2)
+            {
+                if (b1 < b2) { Left = Math.Max(a1, b1); Right = Math.Min(a2, b2); }
+                else { Left = Math.Max(a1, b2); Right = Math.Min(a2, b1); }
+            }
+            else
+            {
+                if (b1 < b2) { Left = Math.Max(a2, b1); Right = Math.Min(a1, b2); }
+                else { Left = Math.Max(a2, b2); Right = Math.Min(a1, b1); }
+            }
+            return Left < Right;
+        }
+        //------------------------------------------------------------------------------
+
+        bool JoinHorz(OutPt op1, OutPt op1b, OutPt op2, OutPt op2b,
+          IntPoint Pt, bool DiscardLeft)
+        {
+            Direction Dir1 = (op1.Pt.X > op1b.Pt.X ?
+              Direction.dRightToLeft : Direction.dLeftToRight);
+            Direction Dir2 = (op2.Pt.X > op2b.Pt.X ?
+              Direction.dRightToLeft : Direction.dLeftToRight);
+            if (Dir1 == Dir2) return false;
+
+            //When DiscardLeft, we want Op1b to be on the Left of Op1, otherwise we
+            //want Op1b to be on the Right. (And likewise with Op2 and Op2b.)
+            //So, to facilitate this while inserting Op1b and Op2b ...
+            //when DiscardLeft, make sure we're AT or RIGHT of Pt before adding Op1b,
+            //otherwise make sure we're AT or LEFT of Pt. (Likewise with Op2b.)
+            if (Dir1 == Direction.dLeftToRight)
+            {
+                while (op1.Next.Pt.X <= Pt.X &&
+                  op1.Next.Pt.X >= op1.Pt.X && op1.Next.Pt.Y == Pt.Y)
+                    op1 = op1.Next;
+                if (DiscardLeft && (op1.Pt.X != Pt.X)) op1 = op1.Next;
+                op1b = DupOutPt(op1, !DiscardLeft);
+                if (op1b.Pt != Pt)
+                {
+                    op1 = op1b;
+                    op1.Pt = Pt;
+                    op1b = DupOutPt(op1, !DiscardLeft);
+                }
+            }
+            else
+            {
+                while (op1.Next.Pt.X >= Pt.X &&
+                  op1.Next.Pt.X <= op1.Pt.X && op1.Next.Pt.Y == Pt.Y)
+                    op1 = op1.Next;
+                if (!DiscardLeft && (op1.Pt.X != Pt.X)) op1 = op1.Next;
+                op1b = DupOutPt(op1, DiscardLeft);
+                if (op1b.Pt != Pt)
+                {
+                    op1 = op1b;
+                    op1.Pt = Pt;
+                    op1b = DupOutPt(op1, DiscardLeft);
+                }
+            }
+
+            if (Dir2 == Direction.dLeftToRight)
+            {
+                while (op2.Next.Pt.X <= Pt.X &&
+                  op2.Next.Pt.X >= op2.Pt.X && op2.Next.Pt.Y == Pt.Y)
+                    op2 = op2.Next;
+                if (DiscardLeft && (op2.Pt.X != Pt.X)) op2 = op2.Next;
+                op2b = DupOutPt(op2, !DiscardLeft);
+                if (op2b.Pt != Pt)
+                {
+                    op2 = op2b;
+                    op2.Pt = Pt;
+                    op2b = DupOutPt(op2, !DiscardLeft);
+                };
+            }
+            else
+            {
+                while (op2.Next.Pt.X >= Pt.X &&
+                  op2.Next.Pt.X <= op2.Pt.X && op2.Next.Pt.Y == Pt.Y)
+                    op2 = op2.Next;
+                if (!DiscardLeft && (op2.Pt.X != Pt.X)) op2 = op2.Next;
+                op2b = DupOutPt(op2, DiscardLeft);
+                if (op2b.Pt != Pt)
+                {
+                    op2 = op2b;
+                    op2.Pt = Pt;
+                    op2b = DupOutPt(op2, DiscardLeft);
+                };
+            };
+
+            if ((Dir1 == Direction.dLeftToRight) == DiscardLeft)
+            {
+                op1.Prev = op2;
+                op2.Next = op1;
+                op1b.Next = op2b;
+                op2b.Prev = op1b;
+            }
+            else
+            {
+                op1.Next = op2;
+                op2.Prev = op1;
+                op1b.Prev = op2b;
+                op2b.Next = op1b;
+            }
+            return true;
+        }
+        //------------------------------------------------------------------------------
+
+        private bool JoinPoints(Join j, OutRec outRec1, OutRec outRec2)
+        {
+            OutPt op1 = j.OutPt1, op1b;
+            OutPt op2 = j.OutPt2, op2b;
+
+            //There are 3 kinds of joins for output polygons ...
+            //1. Horizontal joins where Join.OutPt1 & Join.OutPt2 are a vertices anywhere
+            //along (horizontal) collinear edges (& Join.OffPt is on the same horizontal).
+            //2. Non-horizontal joins where Join.OutPt1 & Join.OutPt2 are at the same
+            //location at the Bottom of the overlapping segment (& Join.OffPt is above).
+            //3. StrictlySimple joins where edges touch but are not collinear and where
+            //Join.OutPt1, Join.OutPt2 & Join.OffPt all share the same point.
+            bool isHorizontal = (j.OutPt1.Pt.Y == j.OffPt.Y);
+
+            if (isHorizontal && (j.OffPt == j.OutPt1.Pt) && (j.OffPt == j.OutPt2.Pt))
+            {
+                //Strictly Simple join ...
+                if (outRec1 != outRec2) return false;
+                op1b = j.OutPt1.Next;
+                while (op1b != op1 && (op1b.Pt == j.OffPt))
+                    op1b = op1b.Next;
+                bool reverse1 = (op1b.Pt.Y > j.OffPt.Y);
+                op2b = j.OutPt2.Next;
+                while (op2b != op2 && (op2b.Pt == j.OffPt))
+                    op2b = op2b.Next;
+                bool reverse2 = (op2b.Pt.Y > j.OffPt.Y);
+                if (reverse1 == reverse2) return false;
+                if (reverse1)
+                {
+                    op1b = DupOutPt(op1, false);
+                    op2b = DupOutPt(op2, true);
+                    op1.Prev = op2;
+                    op2.Next = op1;
+                    op1b.Next = op2b;
+                    op2b.Prev = op1b;
+                    j.OutPt1 = op1;
+                    j.OutPt2 = op1b;
+                    return true;
                 }
                 else
-                  if (Poly2ContainsPoly1(outrec.Pts, outrec2.Pts))
                 {
-                  //OutRec1 is contained by OutRec2 ...
-                  outrec2.IsHole = outrec.IsHole;
-                  outrec.IsHole = !outrec2.IsHole;
-                  outrec2.FirstLeft = outrec.FirstLeft;
-                  outrec.FirstLeft = outrec2;
-                  if (m_UsingPolyTree) FixupFirstLefts2(outrec, outrec2);
+                    op1b = DupOutPt(op1, true);
+                    op2b = DupOutPt(op2, false);
+                    op1.Next = op2;
+                    op2.Prev = op1;
+                    op1b.Prev = op2b;
+                    op2b.Next = op1b;
+                    j.OutPt1 = op1;
+                    j.OutPt2 = op1b;
+                    return true;
                 }
-                  else
-                {
-                  //the 2 polygons are separate ...
-                  outrec2.IsHole = outrec.IsHole;
-                  outrec2.FirstLeft = outrec.FirstLeft;
-                  if (m_UsingPolyTree) FixupFirstLefts1(outrec, outrec2);
-                }
-                op2 = op; //ie get ready for the next iteration
-              }
-              op2 = op2.Next;
             }
-            op = op.Next;
-          }
-          while (op != outrec.Pts);
-        }
-      }
-      //------------------------------------------------------------------------------
+            else if (isHorizontal)
+            {
+                //treat horizontal joins differently to non-horizontal joins since with
+                //them we're not yet sure where the overlapping is. OutPt1.Pt & OutPt2.Pt
+                //may be anywhere along the horizontal edge.
+                op1b = op1;
+                while (op1.Prev.Pt.Y == op1.Pt.Y && op1.Prev != op1b && op1.Prev != op2)
+                    op1 = op1.Prev;
+                while (op1b.Next.Pt.Y == op1b.Pt.Y && op1b.Next != op1 && op1b.Next != op2)
+                    op1b = op1b.Next;
+                if (op1b.Next == op1 || op1b.Next == op2) return false; //a flat 'polygon'
 
-      internal static double Area(Path poly)
-      {
-        int cnt = (int)poly.Count;
-        if (cnt < 3) return 0;
-        double a = 0;
-        for (int i = 0, j = cnt - 1; i < cnt; ++i)
+                op2b = op2;
+                while (op2.Prev.Pt.Y == op2.Pt.Y && op2.Prev != op2b && op2.Prev != op1b)
+                    op2 = op2.Prev;
+                while (op2b.Next.Pt.Y == op2b.Pt.Y && op2b.Next != op2 && op2b.Next != op1)
+                    op2b = op2b.Next;
+                if (op2b.Next == op2 || op2b.Next == op1) return false; //a flat 'polygon'
+
+                cInt Left, Right;
+                //Op1 -. Op1b & Op2 -. Op2b are the extremites of the horizontal edges
+                if (!GetOverlap(op1.Pt.X, op1b.Pt.X, op2.Pt.X, op2b.Pt.X, out Left, out Right))
+                    return false;
+
+                //DiscardLeftSide: when overlapping edges are joined, a spike will created
+                //which needs to be cleaned up. However, we don't want Op1 or Op2 caught up
+                //on the discard Side as either may still be needed for other joins ...
+                IntPoint Pt;
+                bool DiscardLeftSide;
+                if (op1.Pt.X >= Left && op1.Pt.X <= Right)
+                {
+                    Pt = op1.Pt; DiscardLeftSide = (op1.Pt.X > op1b.Pt.X);
+                }
+                else if (op2.Pt.X >= Left && op2.Pt.X <= Right)
+                {
+                    Pt = op2.Pt; DiscardLeftSide = (op2.Pt.X > op2b.Pt.X);
+                }
+                else if (op1b.Pt.X >= Left && op1b.Pt.X <= Right)
+                {
+                    Pt = op1b.Pt; DiscardLeftSide = op1b.Pt.X > op1.Pt.X;
+                }
+                else
+                {
+                    Pt = op2b.Pt; DiscardLeftSide = (op2b.Pt.X > op2.Pt.X);
+                }
+                j.OutPt1 = op1;
+                j.OutPt2 = op2;
+                return JoinHorz(op1, op1b, op2, op2b, Pt, DiscardLeftSide);
+            }
+            else
+            {
+                //nb: For non-horizontal joins ...
+                //    1. Jr.OutPt1.Pt.Y == Jr.OutPt2.Pt.Y
+                //    2. Jr.OutPt1.Pt > Jr.OffPt.Y
+
+                //make sure the polygons are correctly oriented ...
+                op1b = op1.Next;
+                while ((op1b.Pt == op1.Pt) && (op1b != op1)) op1b = op1b.Next;
+                bool Reverse1 = ((op1b.Pt.Y > op1.Pt.Y) ||
+                  !SlopesEqual(op1.Pt, op1b.Pt, j.OffPt, MUseFullRange));
+                if (Reverse1)
+                {
+                    op1b = op1.Prev;
+                    while ((op1b.Pt == op1.Pt) && (op1b != op1)) op1b = op1b.Prev;
+                    if ((op1b.Pt.Y > op1.Pt.Y) ||
+                      !SlopesEqual(op1.Pt, op1b.Pt, j.OffPt, MUseFullRange)) return false;
+                };
+                op2b = op2.Next;
+                while ((op2b.Pt == op2.Pt) && (op2b != op2)) op2b = op2b.Next;
+                bool Reverse2 = ((op2b.Pt.Y > op2.Pt.Y) ||
+                  !SlopesEqual(op2.Pt, op2b.Pt, j.OffPt, MUseFullRange));
+                if (Reverse2)
+                {
+                    op2b = op2.Prev;
+                    while ((op2b.Pt == op2.Pt) && (op2b != op2)) op2b = op2b.Prev;
+                    if ((op2b.Pt.Y > op2.Pt.Y) ||
+                      !SlopesEqual(op2.Pt, op2b.Pt, j.OffPt, MUseFullRange)) return false;
+                }
+
+                if ((op1b == op1) || (op2b == op2) || (op1b == op2b) ||
+                  ((outRec1 == outRec2) && (Reverse1 == Reverse2))) return false;
+
+                if (Reverse1)
+                {
+                    op1b = DupOutPt(op1, false);
+                    op2b = DupOutPt(op2, true);
+                    op1.Prev = op2;
+                    op2.Next = op1;
+                    op1b.Next = op2b;
+                    op2b.Prev = op1b;
+                    j.OutPt1 = op1;
+                    j.OutPt2 = op1b;
+                    return true;
+                }
+                else
+                {
+                    op1b = DupOutPt(op1, true);
+                    op2b = DupOutPt(op2, false);
+                    op1.Next = op2;
+                    op2.Prev = op1;
+                    op1b.Prev = op2b;
+                    op2b.Next = op1b;
+                    j.OutPt1 = op1;
+                    j.OutPt2 = op1b;
+                    return true;
+                }
+            }
+        }
+        //----------------------------------------------------------------------
+
+        internal static int PointInPolygon(IntPoint pt, Path path)
         {
-          a += ((double)poly[j].X + poly[i].X) * ((double)poly[j].Y - poly[i].Y);
-          j = i;
+            //returns 0 if false, +1 if true, -1 if pt ON polygon boundary
+            //See "The Point in Polygon Problem for Arbitrary Polygons" by Hormann & Agathos
+            //http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.88.5498&rep=rep1&type=pdf
+            int result = 0, cnt = path.Count;
+            if (cnt < 3) return 0;
+            IntPoint ip = path[0];
+            for (int i = 1; i <= cnt; ++i)
+            {
+                IntPoint ipNext = (i == cnt ? path[0] : path[i]);
+                if (ipNext.Y == pt.Y)
+                {
+                    if ((ipNext.X == pt.X) || (ip.Y == pt.Y &&
+                      ((ipNext.X > pt.X) == (ip.X < pt.X)))) return -1;
+                }
+                if ((ip.Y < pt.Y) != (ipNext.Y < pt.Y))
+                {
+                    if (ip.X >= pt.X)
+                    {
+                        if (ipNext.X > pt.X) result = 1 - result;
+                        else
+                        {
+                            double d = (double)(ip.X - pt.X) * (ipNext.Y - pt.Y) -
+                              (double)(ipNext.X - pt.X) * (ip.Y - pt.Y);
+                            if (d == 0) return -1;
+                            else if ((d > 0) == (ipNext.Y > ip.Y)) result = 1 - result;
+                        }
+                    }
+                    else
+                    {
+                        if (ipNext.X > pt.X)
+                        {
+                            double d = (double)(ip.X - pt.X) * (ipNext.Y - pt.Y) -
+                              (double)(ipNext.X - pt.X) * (ip.Y - pt.Y);
+                            if (d == 0) return -1;
+                            else if ((d > 0) == (ipNext.Y > ip.Y)) result = 1 - result;
+                        }
+                    }
+                }
+                ip = ipNext;
+            }
+            return result;
         }
-        return -a * 0.5;
-      }
-      //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-      double Area(OutRec outRec)
-      {
-        OutPt op = outRec.Pts;
-        if (op == null) return 0;
-        double a = 0;
-        do {
-          a = a + (double)(op.Prev.Pt.X + op.Pt.X) * (double)(op.Prev.Pt.Y - op.Pt.Y);
-          op = op.Next;
-        } while (op != outRec.Pts);
-        return a * 0.5;
-      }
+        private static int PointInPolygon(IntPoint pt, OutPt op)
+        {
+            //returns 0 if false, +1 if true, -1 if pt ON polygon boundary
+            //See "The Point in Polygon Problem for Arbitrary Polygons" by Hormann & Agathos
+            //http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.88.5498&rep=rep1&type=pdf
+            int result = 0;
+            OutPt startOp = op;
+            cInt ptx = pt.X, pty = pt.Y;
+            cInt poly0x = op.Pt.X, poly0y = op.Pt.Y;
+            do
+            {
+                op = op.Next;
+                cInt poly1x = op.Pt.X, poly1y = op.Pt.Y;
 
-      //------------------------------------------------------------------------------
-      // SimplifyPolygon functions ...
-      // Convert self-intersecting polygons into simple polygons
-      //------------------------------------------------------------------------------
+                if (poly1y == pty)
+                {
+                    if ((poly1x == ptx) || (poly0y == pty &&
+                      ((poly1x > ptx) == (poly0x < ptx)))) return -1;
+                }
+                if ((poly0y < pty) != (poly1y < pty))
+                {
+                    if (poly0x >= ptx)
+                    {
+                        if (poly1x > ptx) result = 1 - result;
+                        else
+                        {
+                            double d = (double)(poly0x - ptx) * (poly1y - pty) -
+                              (double)(poly1x - ptx) * (poly0y - pty);
+                            if (d == 0) return -1;
+                            if ((d > 0) == (poly1y > poly0y)) result = 1 - result;
+                        }
+                    }
+                    else
+                    {
+                        if (poly1x > ptx)
+                        {
+                            double d = (double)(poly0x - ptx) * (poly1y - pty) -
+                              (double)(poly1x - ptx) * (poly0y - pty);
+                            if (d == 0) return -1;
+                            if ((d > 0) == (poly1y > poly0y)) result = 1 - result;
+                        }
+                    }
+                }
+                poly0x = poly1x; poly0y = poly1y;
+            } while (startOp != op);
+            return result;
+        }
+        //------------------------------------------------------------------------------
 
-      internal static Paths SimplifyPolygon(Path poly, 
+        private static bool Poly2ContainsPoly1(OutPt outPt1, OutPt outPt2)
+        {
+            OutPt op = outPt1;
+            do
+            {
+                //nb: PointInPolygon returns 0 if false, +1 if true, -1 if pt on polygon
+                int res = PointInPolygon(op.Pt, outPt2);
+                if (res >= 0) return res > 0;
+                op = op.Next;
+            }
+            while (op != outPt1);
+            return true;
+        }
+        //----------------------------------------------------------------------
+
+        private void FixupFirstLefts1(OutRec OldOutRec, OutRec NewOutRec)
+        {
+            for (int i = 0; i < m_PolyOuts.Count; i++)
+            {
+                OutRec outRec = m_PolyOuts[i];
+                if (outRec.Pts == null || outRec.FirstLeft == null) continue;
+                OutRec firstLeft = ParseFirstLeft(outRec.FirstLeft);
+                if (firstLeft == OldOutRec)
+                {
+                    if (Poly2ContainsPoly1(outRec.Pts, NewOutRec.Pts))
+                        outRec.FirstLeft = NewOutRec;
+                }
+            }
+        }
+        //----------------------------------------------------------------------
+
+        private void FixupFirstLefts2(OutRec OldOutRec, OutRec NewOutRec)
+        {
+            foreach (OutRec outRec in m_PolyOuts)
+                if (outRec.FirstLeft == OldOutRec) outRec.FirstLeft = NewOutRec;
+        }
+        //----------------------------------------------------------------------
+
+        private static OutRec ParseFirstLeft(OutRec FirstLeft)
+        {
+            while (FirstLeft != null && FirstLeft.Pts == null)
+                FirstLeft = FirstLeft.FirstLeft;
+            return FirstLeft;
+        }
+        //------------------------------------------------------------------------------
+
+        private void JoinCommonEdges()
+        {
+            for (int i = 0; i < m_Joins.Count; i++)
+            {
+                Join join = m_Joins[i];
+
+                OutRec outRec1 = GetOutRec(join.OutPt1.Idx);
+                OutRec outRec2 = GetOutRec(join.OutPt2.Idx);
+
+                if (outRec1.Pts == null || outRec2.Pts == null) continue;
+
+                //get the polygon fragment with the correct hole state (FirstLeft)
+                //before calling JoinPoints() ...
+                OutRec holeStateRec;
+                if (outRec1 == outRec2) holeStateRec = outRec1;
+                else if (Param1RightOfParam2(outRec1, outRec2)) holeStateRec = outRec2;
+                else if (Param1RightOfParam2(outRec2, outRec1)) holeStateRec = outRec1;
+                else holeStateRec = GetLowermostRec(outRec1, outRec2);
+
+                if (!JoinPoints(join, outRec1, outRec2)) continue;
+
+                if (outRec1 == outRec2)
+                {
+                    //instead of joining two polygons, we've just created a new one by
+                    //splitting one polygon into two.
+                    outRec1.Pts = join.OutPt1;
+                    outRec1.BottomPt = null;
+                    outRec2 = CreateOutRec();
+                    outRec2.Pts = join.OutPt2;
+
+                    //update all OutRec2.Pts Idx's ...
+                    UpdateOutPtIdxs(outRec2);
+
+                    //We now need to check every OutRec.FirstLeft pointer. If it points
+                    //to OutRec1 it may need to point to OutRec2 instead ...
+                    if (m_UsingPolyTree)
+                        for (int j = 0; j < m_PolyOuts.Count - 1; j++)
+                        {
+                            OutRec oRec = m_PolyOuts[j];
+                            if (oRec.Pts == null || ParseFirstLeft(oRec.FirstLeft) != outRec1 ||
+                              oRec.IsHole == outRec1.IsHole) continue;
+                            if (Poly2ContainsPoly1(oRec.Pts, join.OutPt2))
+                                oRec.FirstLeft = outRec2;
+                        }
+
+                    if (Poly2ContainsPoly1(outRec2.Pts, outRec1.Pts))
+                    {
+                        //outRec2 is contained by outRec1 ...
+                        outRec2.IsHole = !outRec1.IsHole;
+                        outRec2.FirstLeft = outRec1;
+
+                        //fixup FirstLeft pointers that may need reassigning to OutRec1
+                        if (m_UsingPolyTree) FixupFirstLefts2(outRec2, outRec1);
+
+                        if ((outRec2.IsHole ^ ReverseSolution) == (Area(outRec2) > 0))
+                            ReversePolyPtLinks(outRec2.Pts);
+
+                    }
+                    else if (Poly2ContainsPoly1(outRec1.Pts, outRec2.Pts))
+                    {
+                        //outRec1 is contained by outRec2 ...
+                        outRec2.IsHole = outRec1.IsHole;
+                        outRec1.IsHole = !outRec2.IsHole;
+                        outRec2.FirstLeft = outRec1.FirstLeft;
+                        outRec1.FirstLeft = outRec2;
+
+                        //fixup FirstLeft pointers that may need reassigning to OutRec1
+                        if (m_UsingPolyTree) FixupFirstLefts2(outRec1, outRec2);
+
+                        if ((outRec1.IsHole ^ ReverseSolution) == (Area(outRec1) > 0))
+                            ReversePolyPtLinks(outRec1.Pts);
+                    }
+                    else
+                    {
+                        //the 2 polygons are completely separate ...
+                        outRec2.IsHole = outRec1.IsHole;
+                        outRec2.FirstLeft = outRec1.FirstLeft;
+
+                        //fixup FirstLeft pointers that may need reassigning to OutRec2
+                        if (m_UsingPolyTree) FixupFirstLefts1(outRec1, outRec2);
+                    }
+
+                }
+                else
+                {
+                    //joined 2 polygons together ...
+
+                    outRec2.Pts = null;
+                    outRec2.BottomPt = null;
+                    outRec2.Idx = outRec1.Idx;
+
+                    outRec1.IsHole = holeStateRec.IsHole;
+                    if (holeStateRec == outRec2)
+                        outRec1.FirstLeft = outRec2.FirstLeft;
+                    outRec2.FirstLeft = outRec1;
+
+                    //fixup FirstLeft pointers that may need reassigning to OutRec1
+                    if (m_UsingPolyTree) FixupFirstLefts2(outRec2, outRec1);
+                }
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        private void UpdateOutPtIdxs(OutRec outrec)
+        {
+            OutPt op = outrec.Pts;
+            do
+            {
+                op.Idx = outrec.Idx;
+                op = op.Prev;
+            }
+            while (op != outrec.Pts);
+        }
+        //------------------------------------------------------------------------------
+
+        private void DoSimplePolygons()
+        {
+            int i = 0;
+            while (i < m_PolyOuts.Count)
+            {
+                OutRec outrec = m_PolyOuts[i++];
+                OutPt op = outrec.Pts;
+                if (op == null || outrec.IsOpen) continue;
+                do //for each Pt in Polygon until duplicate found do ...
+                {
+                    OutPt op2 = op.Next;
+                    while (op2 != outrec.Pts)
+                    {
+                        if ((op.Pt == op2.Pt) && op2.Next != op && op2.Prev != op)
+                        {
+                            //split the polygon into two ...
+                            OutPt op3 = op.Prev;
+                            OutPt op4 = op2.Prev;
+                            op.Prev = op4;
+                            op4.Next = op;
+                            op2.Prev = op3;
+                            op3.Next = op2;
+
+                            outrec.Pts = op;
+                            OutRec outrec2 = CreateOutRec();
+                            outrec2.Pts = op2;
+                            UpdateOutPtIdxs(outrec2);
+                            if (Poly2ContainsPoly1(outrec2.Pts, outrec.Pts))
+                            {
+                                //OutRec2 is contained by OutRec1 ...
+                                outrec2.IsHole = !outrec.IsHole;
+                                outrec2.FirstLeft = outrec;
+                                if (m_UsingPolyTree) FixupFirstLefts2(outrec2, outrec);
+                            }
+                            else
+                              if (Poly2ContainsPoly1(outrec.Pts, outrec2.Pts))
+                            {
+                                //OutRec1 is contained by OutRec2 ...
+                                outrec2.IsHole = outrec.IsHole;
+                                outrec.IsHole = !outrec2.IsHole;
+                                outrec2.FirstLeft = outrec.FirstLeft;
+                                outrec.FirstLeft = outrec2;
+                                if (m_UsingPolyTree) FixupFirstLefts2(outrec, outrec2);
+                            }
+                            else
+                            {
+                                //the 2 polygons are separate ...
+                                outrec2.IsHole = outrec.IsHole;
+                                outrec2.FirstLeft = outrec.FirstLeft;
+                                if (m_UsingPolyTree) FixupFirstLefts1(outrec, outrec2);
+                            }
+                            op2 = op; //ie get ready for the next iteration
+                        }
+                        op2 = op2.Next;
+                    }
+                    op = op.Next;
+                }
+                while (op != outrec.Pts);
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        internal static double Area(Path poly)
+        {
+            int cnt = (int)poly.Count;
+            if (cnt < 3) return 0;
+            double a = 0;
+            for (int i = 0, j = cnt - 1; i < cnt; ++i)
+            {
+                a += ((double)poly[j].X + poly[i].X) * ((double)poly[j].Y - poly[i].Y);
+                j = i;
+            }
+            return -a * 0.5;
+        }
+        //------------------------------------------------------------------------------
+
+        double Area(OutRec outRec)
+        {
+            OutPt op = outRec.Pts;
+            if (op == null) return 0;
+            double a = 0;
+            do
+            {
+                a = a + (double)(op.Prev.Pt.X + op.Pt.X) * (double)(op.Prev.Pt.Y - op.Pt.Y);
+                op = op.Next;
+            } while (op != outRec.Pts);
+            return a * 0.5;
+        }
+
+        //------------------------------------------------------------------------------
+        // SimplifyPolygon functions ...
+        // Convert self-intersecting polygons into simple polygons
+        //------------------------------------------------------------------------------
+
+        internal static Paths SimplifyPolygon(Path poly,
+              PolyFillType fillType = PolyFillType.pftEvenOdd)
+        {
+            Paths result = new Paths();
+            Clipper c = new Clipper();
+            c.StrictlySimple = true;
+            c.AddPath(poly, PolyType.ptSubject, true);
+            c.Execute(ClipType.ctUnion, result, fillType, fillType);
+            return result;
+        }
+        //------------------------------------------------------------------------------
+
+        internal static Paths SimplifyPolygons(Paths polys,
             PolyFillType fillType = PolyFillType.pftEvenOdd)
-      {
-          Paths result = new Paths();
-          Clipper c = new Clipper();
-          c.StrictlySimple = true;
-          c.AddPath(poly, PolyType.ptSubject, true);
-          c.Execute(ClipType.ctUnion, result, fillType, fillType);
-          return result;
-      }
-      //------------------------------------------------------------------------------
-
-      internal static Paths SimplifyPolygons(Paths polys,
-          PolyFillType fillType = PolyFillType.pftEvenOdd)
-      {
-          Paths result = new Paths();
-          Clipper c = new Clipper();
-          c.StrictlySimple = true;
-          c.AddPaths(polys, PolyType.ptSubject, true);
-          c.Execute(ClipType.ctUnion, result, fillType, fillType);
-          return result;
-      }
-      //------------------------------------------------------------------------------
-
-      private static double DistanceSqrd(IntPoint pt1, IntPoint pt2)
-      {
-        double dx = ((double)pt1.X - pt2.X);
-        double dy = ((double)pt1.Y - pt2.Y);
-        return (dx*dx + dy*dy);
-      }
-      //------------------------------------------------------------------------------
-
-      private static double DistanceFromLineSqrd(IntPoint pt, IntPoint ln1, IntPoint ln2)
-      {
-        //The equation of a line in general form (Ax + By + C = 0)
-        //given 2 points (x¹,y¹) & (x²,y²) is ...
-        //(y¹ - y²)x + (x² - x¹)y + (y² - y¹)x¹ - (x² - x¹)y¹ = 0
-        //A = (y¹ - y²); B = (x² - x¹); C = (y² - y¹)x¹ - (x² - x¹)y¹
-        //perpendicular distance of point (x³,y³) = (Ax³ + By³ + C)/Sqrt(A² + B²)
-        //see http://en.wikipedia.org/wiki/Perpendicular_distance
-        double A = ln1.Y - ln2.Y;
-        double B = ln2.X - ln1.X;
-        double C = A * ln1.X  + B * ln1.Y;
-        C = A * pt.X + B * pt.Y - C;
-        return (C * C) / (A * A + B * B);
-      }
-      //---------------------------------------------------------------------------
-
-      private static bool SlopesNearCollinear(IntPoint pt1, 
-          IntPoint pt2, IntPoint pt3, double distSqrd)
-      {
-        //this function is more accurate when the point that's GEOMETRICALLY 
-        //between the other 2 points is the one that's tested for distance.  
-        //nb: with 'spikes', either pt1 or pt3 is geometrically between the other pts                    
-        if (Math.Abs(pt1.X - pt2.X) > Math.Abs(pt1.Y - pt2.Y))
-	      {
-          if ((pt1.X > pt2.X) == (pt1.X < pt3.X))
-            return DistanceFromLineSqrd(pt1, pt2, pt3) < distSqrd;
-          else if ((pt2.X > pt1.X) == (pt2.X < pt3.X))
-            return DistanceFromLineSqrd(pt2, pt1, pt3) < distSqrd;
-		      else
-	          return DistanceFromLineSqrd(pt3, pt1, pt2) < distSqrd;
-	      }
-	      else
-	      {
-          if ((pt1.Y > pt2.Y) == (pt1.Y < pt3.Y))
-            return DistanceFromLineSqrd(pt1, pt2, pt3) < distSqrd;
-          else if ((pt2.Y > pt1.Y) == (pt2.Y < pt3.Y))
-            return DistanceFromLineSqrd(pt2, pt1, pt3) < distSqrd;
-		      else
-            return DistanceFromLineSqrd(pt3, pt1, pt2) < distSqrd;
-	      }
-      }
-      //------------------------------------------------------------------------------
-
-      private static bool PointsAreClose(IntPoint pt1, IntPoint pt2, double distSqrd)
-      {
-          double dx = (double)pt1.X - pt2.X;
-          double dy = (double)pt1.Y - pt2.Y;
-          return ((dx * dx) + (dy * dy) <= distSqrd);
-      }
-      //------------------------------------------------------------------------------
-
-      private static OutPt ExcludeOp(OutPt op)
-      {
-        OutPt result = op.Prev;
-        result.Next = op.Next;
-        op.Next.Prev = result;
-        result.Idx = 0;
-        return result;
-      }
-      //------------------------------------------------------------------------------
-
-      internal static Path CleanPolygon(Path path, double distance = 1.415)
-      {
-        //distance = proximity in units/pixels below which vertices will be stripped. 
-        //Default ~= sqrt(2) so when adjacent vertices or semi-adjacent vertices have 
-        //both x & y coords within 1 unit, then the second vertex will be stripped.
-
-        int cnt = path.Count;
-
-        if (cnt == 0) return new Path();
-
-        OutPt [] outPts = new OutPt[cnt];
-        for (int i = 0; i < cnt; ++i) outPts[i] = new OutPt();
-
-        for (int i = 0; i < cnt; ++i)
         {
-          outPts[i].Pt = path[i];
-          outPts[i].Next = outPts[(i + 1) % cnt];
-          outPts[i].Next.Prev = outPts[i];
-          outPts[i].Idx = 0;
+            Paths result = new Paths();
+            Clipper c = new Clipper();
+            c.StrictlySimple = true;
+            c.AddPaths(polys, PolyType.ptSubject, true);
+            c.Execute(ClipType.ctUnion, result, fillType, fillType);
+            return result;
         }
+        //------------------------------------------------------------------------------
 
-        double distSqrd = distance * distance;
-        OutPt op = outPts[0];
-        while (op.Idx == 0 && op.Next != op.Prev)
+        private static double DistanceSqrd(IntPoint pt1, IntPoint pt2)
         {
-          if (PointsAreClose(op.Pt, op.Prev.Pt, distSqrd))
-          {
-            op = ExcludeOp(op);
-            cnt--;
-          }
-          else if (PointsAreClose(op.Prev.Pt, op.Next.Pt, distSqrd))
-          {
-            ExcludeOp(op.Next);
-            op = ExcludeOp(op);
-            cnt -= 2;
-          }
-          else if (SlopesNearCollinear(op.Prev.Pt, op.Pt, op.Next.Pt, distSqrd))
-          {
-            op = ExcludeOp(op);
-            cnt--;
-          }
-          else
-          {
-            op.Idx = 1;
-            op = op.Next;
-          }
+            double dx = ((double)pt1.X - pt2.X);
+            double dy = ((double)pt1.Y - pt2.Y);
+            return (dx * dx + dy * dy);
         }
+        //------------------------------------------------------------------------------
 
-        if (cnt < 3) cnt = 0;
-        Path result = new Path(cnt);
-        for (int i = 0; i < cnt; ++i)
+        private static double DistanceFromLineSqrd(IntPoint pt, IntPoint ln1, IntPoint ln2)
         {
-          result.Add(op.Pt);
-          op = op.Next;
+            //The equation of a line in general form (Ax + By + C = 0)
+            //given 2 points (x¹,y¹) & (x²,y²) is ...
+            //(y¹ - y²)x + (x² - x¹)y + (y² - y¹)x¹ - (x² - x¹)y¹ = 0
+            //A = (y¹ - y²); B = (x² - x¹); C = (y² - y¹)x¹ - (x² - x¹)y¹
+            //perpendicular distance of point (x³,y³) = (Ax³ + By³ + C)/Sqrt(A² + B²)
+            //see http://en.wikipedia.org/wiki/Perpendicular_distance
+            double A = ln1.Y - ln2.Y;
+            double B = ln2.X - ln1.X;
+            double C = A * ln1.X + B * ln1.Y;
+            C = A * pt.X + B * pt.Y - C;
+            return (C * C) / (A * A + B * B);
         }
-        outPts = null;
-        return result;
-      }
-      //------------------------------------------------------------------------------
+        //---------------------------------------------------------------------------
 
-      internal static Paths CleanPolygons(Paths polys,
-          double distance = 1.415)
-      {
-        Paths result = new Paths(polys.Count);
-        for (int i = 0; i < polys.Count; i++)
-          result.Add(CleanPolygon(polys[i], distance));
-        return result;
-      }
-      //------------------------------------------------------------------------------
-
-      internal static Paths Minkowski(Path pattern, Path path, bool IsSum, bool IsClosed)
-      {
-        int delta = (IsClosed ? 1 : 0);
-        int polyCnt = pattern.Count;
-        int pathCnt = path.Count;
-        Paths result = new Paths(pathCnt);
-        if (IsSum)
-          for (int i = 0; i < pathCnt; i++)
-          {
-            Path p = new Path(polyCnt);
-            foreach (IntPoint ip in pattern)
-              p.Add(new IntPoint(path[i].X + ip.X, path[i].Y + ip.Y));
-            result.Add(p);
-          }
-        else
-          for (int i = 0; i < pathCnt; i++)
-          {
-            Path p = new Path(polyCnt);
-            foreach (IntPoint ip in pattern)
-              p.Add(new IntPoint(path[i].X - ip.X, path[i].Y - ip.Y));
-            result.Add(p);
-          }
-
-        Paths quads = new Paths((pathCnt + delta) * (polyCnt + 1));
-        for (int i = 0; i < pathCnt - 1 + delta; i++)
-          for (int j = 0; j < polyCnt; j++)
-          {
-            Path quad = new Path(4);
-            quad.Add(result[i % pathCnt][j % polyCnt]);
-            quad.Add(result[(i + 1) % pathCnt][j % polyCnt]);
-            quad.Add(result[(i + 1) % pathCnt][(j + 1) % polyCnt]);
-            quad.Add(result[i % pathCnt][(j + 1) % polyCnt]);
-            if (!Orientation(quad)) quad.Reverse();
-            quads.Add(quad);
-          }
-        return quads;
-      }
-      //------------------------------------------------------------------------------
-
-      internal static Paths MinkowskiSum(Path pattern, Path path, bool pathIsClosed)
-      {
-        Paths paths = Minkowski(pattern, path, true, pathIsClosed);
-        Clipper c = new Clipper();
-        c.AddPaths(paths, PolyType.ptSubject, true);
-        c.Execute(ClipType.ctUnion, paths, PolyFillType.pftNonZero, PolyFillType.pftNonZero);
-        return paths;
-      }
-      //------------------------------------------------------------------------------
-
-      private static Path TranslatePath(Path path, IntPoint delta) 
-      {
-        Path outPath = new Path(path.Count);
-        for (int i = 0; i < path.Count; i++)
-          outPath.Add(new IntPoint(path[i].X + delta.X, path[i].Y + delta.Y));
-        return outPath;
-      }
-      //------------------------------------------------------------------------------
-
-      internal static Paths MinkowskiSum(Path pattern, Paths paths, bool pathIsClosed)
-      {
-        Paths solution = new Paths();
-        Clipper c = new Clipper();
-        for (int i = 0; i < paths.Count; ++i)
+        private static bool SlopesNearCollinear(IntPoint pt1,
+            IntPoint pt2, IntPoint pt3, double distSqrd)
         {
-          Paths tmp = Minkowski(pattern, paths[i], true, pathIsClosed);
-          c.AddPaths(tmp, PolyType.ptSubject, true);
-          if (pathIsClosed)
-          {
-            Path path = TranslatePath(paths[i], pattern[0]);
-            c.AddPath(path, PolyType.ptClip, true);
-          }
+            //this function is more accurate when the point that's GEOMETRICALLY 
+            //between the other 2 points is the one that's tested for distance.  
+            //nb: with 'spikes', either pt1 or pt3 is geometrically between the other pts                    
+            if (Math.Abs(pt1.X - pt2.X) > Math.Abs(pt1.Y - pt2.Y))
+            {
+                if ((pt1.X > pt2.X) == (pt1.X < pt3.X))
+                    return DistanceFromLineSqrd(pt1, pt2, pt3) < distSqrd;
+                else if ((pt2.X > pt1.X) == (pt2.X < pt3.X))
+                    return DistanceFromLineSqrd(pt2, pt1, pt3) < distSqrd;
+                else
+                    return DistanceFromLineSqrd(pt3, pt1, pt2) < distSqrd;
+            }
+            else
+            {
+                if ((pt1.Y > pt2.Y) == (pt1.Y < pt3.Y))
+                    return DistanceFromLineSqrd(pt1, pt2, pt3) < distSqrd;
+                else if ((pt2.Y > pt1.Y) == (pt2.Y < pt3.Y))
+                    return DistanceFromLineSqrd(pt2, pt1, pt3) < distSqrd;
+                else
+                    return DistanceFromLineSqrd(pt3, pt1, pt2) < distSqrd;
+            }
         }
-        c.Execute(ClipType.ctUnion, solution, 
-          PolyFillType.pftNonZero, PolyFillType.pftNonZero);
-        return solution;
-      }
-      //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-      internal static Paths MinkowskiDiff(Path poly1, Path poly2)
-      {
-        Paths paths = Minkowski(poly1, poly2, false, true);
-        Clipper c = new Clipper();
-        c.AddPaths(paths, PolyType.ptSubject, true);
-        c.Execute(ClipType.ctUnion, paths, PolyFillType.pftNonZero, PolyFillType.pftNonZero);
-        return paths;
-      }
-      //------------------------------------------------------------------------------
-
-      internal enum NodeType { ntAny, ntOpen, ntClosed };
-
-      internal static Paths PolyTreeToPaths(PolyTree polytree)
-      {
-
-        Paths result = new Paths();
-        result.Capacity = polytree.Total;
-        AddPolyNodeToPaths(polytree, NodeType.ntAny, result);
-        return result;
-      }
-      //------------------------------------------------------------------------------
-
-      internal static void AddPolyNodeToPaths(PolyNode polynode, NodeType nt, Paths paths)
-      {
-        bool match = true;
-        switch (nt)
+        private static bool PointsAreClose(IntPoint pt1, IntPoint pt2, double distSqrd)
         {
-          case NodeType.ntOpen: return;
-          case NodeType.ntClosed: match = !polynode.IsOpen; break;
-          default: break;
+            double dx = (double)pt1.X - pt2.X;
+            double dy = (double)pt1.Y - pt2.Y;
+            return ((dx * dx) + (dy * dy) <= distSqrd);
         }
+        //------------------------------------------------------------------------------
 
-        if (polynode.MPolygon.Count > 0 && match)
-          paths.Add(polynode.MPolygon);
-        foreach (PolyNode pn in polynode.Childs)
-          AddPolyNodeToPaths(pn, nt, paths);
-      }
-      //------------------------------------------------------------------------------
+        private static OutPt ExcludeOp(OutPt op)
+        {
+            OutPt result = op.Prev;
+            result.Next = op.Next;
+            op.Next.Prev = result;
+            result.Idx = 0;
+            return result;
+        }
+        //------------------------------------------------------------------------------
 
-      internal static Paths OpenPathsFromPolyTree(PolyTree polytree)
-      {
-        Paths result = new Paths();
-        result.Capacity = polytree.ChildCount;
-        for (int i = 0; i < polytree.ChildCount; i++)
-          if (polytree.Childs[i].IsOpen)
-            result.Add(polytree.Childs[i].MPolygon);
-        return result;
-      }
-      //------------------------------------------------------------------------------
+        internal static Path CleanPolygon(Path path, double distance = 1.415)
+        {
+            //distance = proximity in units/pixels below which vertices will be stripped. 
+            //Default ~= sqrt(2) so when adjacent vertices or semi-adjacent vertices have 
+            //both x & y coords within 1 unit, then the second vertex will be stripped.
 
-      internal static Paths ClosedPathsFromPolyTree(PolyTree polytree)
-      {
-        Paths result = new Paths();
-        result.Capacity = polytree.Total;
-        AddPolyNodeToPaths(polytree, NodeType.ntClosed, result);
-        return result;
-      }
-      //------------------------------------------------------------------------------
+            int cnt = path.Count;
 
-  } //end Clipper
+            if (cnt == 0) return new Path();
+
+            OutPt[] outPts = new OutPt[cnt];
+            for (int i = 0; i < cnt; ++i) outPts[i] = new OutPt();
+
+            for (int i = 0; i < cnt; ++i)
+            {
+                outPts[i].Pt = path[i];
+                outPts[i].Next = outPts[(i + 1) % cnt];
+                outPts[i].Next.Prev = outPts[i];
+                outPts[i].Idx = 0;
+            }
+
+            double distSqrd = distance * distance;
+            OutPt op = outPts[0];
+            while (op.Idx == 0 && op.Next != op.Prev)
+            {
+                if (PointsAreClose(op.Pt, op.Prev.Pt, distSqrd))
+                {
+                    op = ExcludeOp(op);
+                    cnt--;
+                }
+                else if (PointsAreClose(op.Prev.Pt, op.Next.Pt, distSqrd))
+                {
+                    ExcludeOp(op.Next);
+                    op = ExcludeOp(op);
+                    cnt -= 2;
+                }
+                else if (SlopesNearCollinear(op.Prev.Pt, op.Pt, op.Next.Pt, distSqrd))
+                {
+                    op = ExcludeOp(op);
+                    cnt--;
+                }
+                else
+                {
+                    op.Idx = 1;
+                    op = op.Next;
+                }
+            }
+
+            if (cnt < 3) cnt = 0;
+            Path result = new Path(cnt);
+            for (int i = 0; i < cnt; ++i)
+            {
+                result.Add(op.Pt);
+                op = op.Next;
+            }
+            outPts = null;
+            return result;
+        }
+        //------------------------------------------------------------------------------
+
+        internal static Paths CleanPolygons(Paths polys,
+            double distance = 1.415)
+        {
+            Paths result = new Paths(polys.Count);
+            for (int i = 0; i < polys.Count; i++)
+                result.Add(CleanPolygon(polys[i], distance));
+            return result;
+        }
+        //------------------------------------------------------------------------------
+
+        internal static Paths Minkowski(Path pattern, Path path, bool IsSum, bool IsClosed)
+        {
+            int delta = (IsClosed ? 1 : 0);
+            int polyCnt = pattern.Count;
+            int pathCnt = path.Count;
+            Paths result = new Paths(pathCnt);
+            if (IsSum)
+                for (int i = 0; i < pathCnt; i++)
+                {
+                    Path p = new Path(polyCnt);
+                    foreach (IntPoint ip in pattern)
+                        p.Add(new IntPoint(path[i].X + ip.X, path[i].Y + ip.Y));
+                    result.Add(p);
+                }
+            else
+                for (int i = 0; i < pathCnt; i++)
+                {
+                    Path p = new Path(polyCnt);
+                    foreach (IntPoint ip in pattern)
+                        p.Add(new IntPoint(path[i].X - ip.X, path[i].Y - ip.Y));
+                    result.Add(p);
+                }
+
+            Paths quads = new Paths((pathCnt + delta) * (polyCnt + 1));
+            for (int i = 0; i < pathCnt - 1 + delta; i++)
+                for (int j = 0; j < polyCnt; j++)
+                {
+                    Path quad = new Path(4);
+                    quad.Add(result[i % pathCnt][j % polyCnt]);
+                    quad.Add(result[(i + 1) % pathCnt][j % polyCnt]);
+                    quad.Add(result[(i + 1) % pathCnt][(j + 1) % polyCnt]);
+                    quad.Add(result[i % pathCnt][(j + 1) % polyCnt]);
+                    if (!Orientation(quad)) quad.Reverse();
+                    quads.Add(quad);
+                }
+            return quads;
+        }
+        //------------------------------------------------------------------------------
+
+        internal static Paths MinkowskiSum(Path pattern, Path path, bool pathIsClosed)
+        {
+            Paths paths = Minkowski(pattern, path, true, pathIsClosed);
+            Clipper c = new Clipper();
+            c.AddPaths(paths, PolyType.ptSubject, true);
+            c.Execute(ClipType.ctUnion, paths, PolyFillType.pftNonZero, PolyFillType.pftNonZero);
+            return paths;
+        }
+        //------------------------------------------------------------------------------
+
+        private static Path TranslatePath(Path path, IntPoint delta)
+        {
+            Path outPath = new Path(path.Count);
+            for (int i = 0; i < path.Count; i++)
+                outPath.Add(new IntPoint(path[i].X + delta.X, path[i].Y + delta.Y));
+            return outPath;
+        }
+        //------------------------------------------------------------------------------
+
+        internal static Paths MinkowskiSum(Path pattern, Paths paths, bool pathIsClosed)
+        {
+            Paths solution = new Paths();
+            Clipper c = new Clipper();
+            for (int i = 0; i < paths.Count; ++i)
+            {
+                Paths tmp = Minkowski(pattern, paths[i], true, pathIsClosed);
+                c.AddPaths(tmp, PolyType.ptSubject, true);
+                if (pathIsClosed)
+                {
+                    Path path = TranslatePath(paths[i], pattern[0]);
+                    c.AddPath(path, PolyType.ptClip, true);
+                }
+            }
+            c.Execute(ClipType.ctUnion, solution,
+              PolyFillType.pftNonZero, PolyFillType.pftNonZero);
+            return solution;
+        }
+        //------------------------------------------------------------------------------
+
+        internal static Paths MinkowskiDiff(Path poly1, Path poly2)
+        {
+            Paths paths = Minkowski(poly1, poly2, false, true);
+            Clipper c = new Clipper();
+            c.AddPaths(paths, PolyType.ptSubject, true);
+            c.Execute(ClipType.ctUnion, paths, PolyFillType.pftNonZero, PolyFillType.pftNonZero);
+            return paths;
+        }
+        //------------------------------------------------------------------------------
+
+        internal enum NodeType { ntAny, ntOpen, ntClosed };
+
+        internal static Paths PolyTreeToPaths(PolyTree polytree)
+        {
+
+            Paths result = new Paths();
+            result.Capacity = polytree.Total;
+            AddPolyNodeToPaths(polytree, NodeType.ntAny, result);
+            return result;
+        }
+        //------------------------------------------------------------------------------
+
+        internal static void AddPolyNodeToPaths(PolyNode polynode, NodeType nt, Paths paths)
+        {
+            bool match = true;
+            switch (nt)
+            {
+                case NodeType.ntOpen: return;
+                case NodeType.ntClosed: match = !polynode.IsOpen; break;
+                default: break;
+            }
+
+            if (polynode.MPolygon.Count > 0 && match)
+                paths.Add(polynode.MPolygon);
+            foreach (PolyNode pn in polynode.Childs)
+                AddPolyNodeToPaths(pn, nt, paths);
+        }
+        //------------------------------------------------------------------------------
+
+        internal static Paths OpenPathsFromPolyTree(PolyTree polytree)
+        {
+            Paths result = new Paths();
+            result.Capacity = polytree.ChildCount;
+            for (int i = 0; i < polytree.ChildCount; i++)
+                if (polytree.Childs[i].IsOpen)
+                    result.Add(polytree.Childs[i].MPolygon);
+            return result;
+        }
+        //------------------------------------------------------------------------------
+
+        internal static Paths ClosedPathsFromPolyTree(PolyTree polytree)
+        {
+            Paths result = new Paths();
+            result.Capacity = polytree.Total;
+            AddPolyNodeToPaths(polytree, NodeType.ntClosed, result);
+            return result;
+        }
+        //------------------------------------------------------------------------------
+
+    } //end Clipper
 
     #endregion 
 
     #region Clipper Offset
     internal class ClipperOffset
-  {
-    private Paths m_destPolys;
-    private Path m_srcPoly;
-    private Path m_destPoly;
-    private List<DoublePoint> m_normals = new List<DoublePoint>();
-    private double m_delta, m_sinA, m_sin, m_cos;
-    private double m_miterLim, m_StepsPerRad;
-
-    private IntPoint m_lowest;
-    private PolyNode m_polyNodes = new PolyNode();
-
-    internal double ArcTolerance { get; set; }
-    internal double MiterLimit { get; set; }
-
-    private const double two_pi = Math.PI * 2;
-    private const double def_arc_tolerance = 0.25;
-
-    internal ClipperOffset(
-      double miterLimit = 2.0, double arcTolerance = def_arc_tolerance)
     {
-      MiterLimit = miterLimit;
-      ArcTolerance = arcTolerance;
-      m_lowest.X = -1;
-    }
-    //------------------------------------------------------------------------------
+        private Paths m_destPolys;
+        private Path m_srcPoly;
+        private Path m_destPoly;
+        private List<DoublePoint> m_normals = new List<DoublePoint>();
+        private double m_delta, m_sinA, m_sin, m_cos;
+        private double m_miterLim, m_StepsPerRad;
 
-    internal void Clear()
-    {
-      m_polyNodes.Childs.Clear();
-      m_lowest.X = -1;
-    }
-    //------------------------------------------------------------------------------
+        private IntPoint m_lowest;
+        private PolyNode m_polyNodes = new PolyNode();
 
-    internal static cInt Round(double value)
-    {
-      return value < 0 ? (cInt)(value - 0.5) : (cInt)(value + 0.5);
-    }
-    //------------------------------------------------------------------------------
+        internal double ArcTolerance { get; set; }
+        internal double MiterLimit { get; set; }
 
-    internal void AddPath(Path path, JoinType joinType, EndType endType)
-    {
-      int highI = path.Count - 1;
-      if (highI < 0) return;
-      PolyNode newNode = new PolyNode();
-      newNode.MJointype = joinType;
-      newNode.MEndtype = endType;
+        private const double two_pi = Math.PI * 2;
+        private const double def_arc_tolerance = 0.25;
 
-      //strip duplicate points from path and also get index to the lowest point ...
-      if (endType == EndType.etClosedLine || endType == EndType.etClosedPolygon)
-        while (highI > 0 && path[0] == path[highI]) highI--;
-      newNode.MPolygon.Capacity = highI + 1;
-      newNode.MPolygon.Add(path[0]);
-      int j = 0, k = 0;
-      for (int i = 1; i <= highI; i++)
-        if (newNode.MPolygon[j] != path[i])
+        internal ClipperOffset(
+          double miterLimit = 2.0, double arcTolerance = def_arc_tolerance)
         {
-          j++;
-          newNode.MPolygon.Add(path[i]);
-          if (path[i].Y > newNode.MPolygon[k].Y ||
-            (path[i].Y == newNode.MPolygon[k].Y &&
-            path[i].X < newNode.MPolygon[k].X)) k = j;
+            MiterLimit = miterLimit;
+            ArcTolerance = arcTolerance;
+            m_lowest.X = -1;
         }
-      if (endType == EndType.etClosedPolygon && j < 2) return;
+        //------------------------------------------------------------------------------
 
-      m_polyNodes.AddChild(newNode);
-
-      //if this path's lowest pt is lower than all the others then update m_lowest
-      if (endType != EndType.etClosedPolygon) return;
-      if (m_lowest.X < 0)
-        m_lowest = new IntPoint(m_polyNodes.ChildCount - 1, k);
-      else
-      {
-        IntPoint ip = m_polyNodes.Childs[(int)m_lowest.X].MPolygon[(int)m_lowest.Y];
-        if (newNode.MPolygon[k].Y > ip.Y ||
-          (newNode.MPolygon[k].Y == ip.Y &&
-          newNode.MPolygon[k].X < ip.X))
-          m_lowest = new IntPoint(m_polyNodes.ChildCount - 1, k);
-      }
-    }
-    //------------------------------------------------------------------------------
-
-    internal void AddPaths(Paths paths, JoinType joinType, EndType endType)
-    {
-      foreach (Path p in paths)
-        AddPath(p, joinType, endType);
-    }
-    //------------------------------------------------------------------------------
-
-    private void FixOrientations()
-    {
-      //fixup orientations of all closed paths if the orientation of the
-      //closed path with the lowermost vertex is wrong ...
-      if (m_lowest.X >= 0 && 
-        !Clipper.Orientation(m_polyNodes.Childs[(int)m_lowest.X].MPolygon))
-      {
-        for (int i = 0; i < m_polyNodes.ChildCount; i++)
+        internal void Clear()
         {
-          PolyNode node = m_polyNodes.Childs[i];
-          if (node.MEndtype == EndType.etClosedPolygon ||
-            (node.MEndtype == EndType.etClosedLine && 
-            Clipper.Orientation(node.MPolygon)))
-            node.MPolygon.Reverse();
+            m_polyNodes.Childs.Clear();
+            m_lowest.X = -1;
         }
-      }
-      else
-      {
-        for (int i = 0; i < m_polyNodes.ChildCount; i++)
+        //------------------------------------------------------------------------------
+
+        internal static cInt Round(double value)
         {
-          PolyNode node = m_polyNodes.Childs[i];
-          if (node.MEndtype == EndType.etClosedLine &&
-            !Clipper.Orientation(node.MPolygon))
-          node.MPolygon.Reverse();
+            return value < 0 ? (cInt)(value - 0.5) : (cInt)(value + 0.5);
         }
-      }
-    }
-    //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-    internal static DoublePoint GetUnitNormal(IntPoint pt1, IntPoint pt2)
-    {
-      double dx = (pt2.X - pt1.X);
-      double dy = (pt2.Y - pt1.Y);
-      if ((dx == 0) && (dy == 0)) return new DoublePoint();
-
-      double f = 1 * 1.0 / Math.Sqrt(dx * dx + dy * dy);
-      dx *= f;
-      dy *= f;
-
-      return new DoublePoint(dy, -dx);
-    }
-    //------------------------------------------------------------------------------
-
-    private void DoOffset(double delta)
-    {
-      m_destPolys = new Paths();
-      m_delta = delta;
-
-      //if Zero offset, just copy any CLOSED polygons to m_p and return ...
-      if (ClipperBase.near_zero(delta)) 
-      {
-        m_destPolys.Capacity = m_polyNodes.ChildCount;
-        for (int i = 0; i < m_polyNodes.ChildCount; i++)
+        internal void AddPath(Path path, JoinType joinType, EndType endType)
         {
-          PolyNode node = m_polyNodes.Childs[i];
-          if (node.MEndtype == EndType.etClosedPolygon)
-            m_destPolys.Add(node.MPolygon);
-        }
-        return;
-      }
+            int highI = path.Count - 1;
+            if (highI < 0) return;
+            PolyNode newNode = new PolyNode();
+            newNode.MJointype = joinType;
+            newNode.MEndtype = endType;
 
-      //see offset_triginometry3.svg in the documentation folder ...
-      if (MiterLimit > 2) m_miterLim = 2 / (MiterLimit * MiterLimit);
-      else m_miterLim = 0.5;
+            //strip duplicate points from path and also get index to the lowest point ...
+            if (endType == EndType.etClosedLine || endType == EndType.etClosedPolygon)
+                while (highI > 0 && path[0] == path[highI]) highI--;
+            newNode.MPolygon.Capacity = highI + 1;
+            newNode.MPolygon.Add(path[0]);
+            int j = 0, k = 0;
+            for (int i = 1; i <= highI; i++)
+                if (newNode.MPolygon[j] != path[i])
+                {
+                    j++;
+                    newNode.MPolygon.Add(path[i]);
+                    if (path[i].Y > newNode.MPolygon[k].Y ||
+                      (path[i].Y == newNode.MPolygon[k].Y &&
+                      path[i].X < newNode.MPolygon[k].X)) k = j;
+                }
+            if (endType == EndType.etClosedPolygon && j < 2) return;
 
-      double y;
-      if (ArcTolerance <= 0.0) 
-        y = def_arc_tolerance;
-      else if (ArcTolerance > Math.Abs(delta) * def_arc_tolerance)
-        y = Math.Abs(delta) * def_arc_tolerance;
-      else 
-        y = ArcTolerance;
-      //see offset_triginometry2.svg in the documentation folder ...
-      double steps = Math.PI / Math.Acos(1 - y / Math.Abs(delta));
-      m_sin = Math.Sin(two_pi / steps);
-      m_cos = Math.Cos(two_pi / steps);
-      m_StepsPerRad = steps / two_pi;
-      if (delta < 0.0) m_sin = -m_sin;
+            m_polyNodes.AddChild(newNode);
 
-      m_destPolys.Capacity = m_polyNodes.ChildCount * 2;
-      for (int i = 0; i < m_polyNodes.ChildCount; i++)
-      {
-        PolyNode node = m_polyNodes.Childs[i];
-        m_srcPoly = node.MPolygon;
-
-        int len = m_srcPoly.Count;
-
-        if (len == 0 || (delta <= 0 && (len < 3 || 
-          node.MEndtype != EndType.etClosedPolygon)))
-            continue;
-
-        m_destPoly = new Path();
-
-        if (len == 1)
-        {
-          if (node.MJointype == JoinType.jtRound)
-          {
-            double X = 1.0, Y = 0.0;
-            for (int j = 1; j <= steps; j++)
-            {
-              m_destPoly.Add(new IntPoint(
-                Round(m_srcPoly[0].X + X * delta),
-                Round(m_srcPoly[0].Y + Y * delta)));
-              double X2 = X;
-              X = X * m_cos - m_sin * Y;
-              Y = X2 * m_sin + Y * m_cos;
-            }
-          }
-          else
-          {
-            double X = -1.0, Y = -1.0;
-            for (int j = 0; j < 4; ++j)
-            {
-              m_destPoly.Add(new IntPoint(
-                Round(m_srcPoly[0].X + X * delta),
-                Round(m_srcPoly[0].Y + Y * delta)));
-              if (X < 0) X = 1;
-              else if (Y < 0) Y = 1;
-              else X = -1;
-            }
-          }
-          m_destPolys.Add(m_destPoly);
-          continue;
-        }
-
-        //build m_normals ...
-        m_normals.Clear();
-        m_normals.Capacity = len;
-        for (int j = 0; j < len - 1; j++)
-          m_normals.Add(GetUnitNormal(m_srcPoly[j], m_srcPoly[j + 1]));
-        if (node.MEndtype == EndType.etClosedLine || 
-          node.MEndtype == EndType.etClosedPolygon)
-          m_normals.Add(GetUnitNormal(m_srcPoly[len - 1], m_srcPoly[0]));
-        else
-          m_normals.Add(new DoublePoint(m_normals[len - 2]));
-
-        if (node.MEndtype == EndType.etClosedPolygon)
-        {
-          int k = len - 1;
-          for (int j = 0; j < len; j++)
-            OffsetPoint(j, ref k, node.MJointype);
-          m_destPolys.Add(m_destPoly);
-        }
-        else if (node.MEndtype == EndType.etClosedLine)
-        {
-          int k = len - 1;
-          for (int j = 0; j < len; j++)
-            OffsetPoint(j, ref k, node.MJointype);
-          m_destPolys.Add(m_destPoly);
-          m_destPoly = new Path();
-          //re-build m_normals ...
-          DoublePoint n = m_normals[len - 1];
-          for (int j = len - 1; j > 0; j--)
-            m_normals[j] = new DoublePoint(-m_normals[j - 1].X, -m_normals[j - 1].Y);
-          m_normals[0] = new DoublePoint(-n.X, -n.Y);
-          k = 0;
-          for (int j = len - 1; j >= 0; j--)
-            OffsetPoint(j, ref k, node.MJointype);
-          m_destPolys.Add(m_destPoly);
-        }
-        else
-        {
-          int k = 0;
-          for (int j = 1; j < len - 1; ++j)
-            OffsetPoint(j, ref k, node.MJointype);
-
-          IntPoint pt1;
-          if (node.MEndtype == EndType.etOpenButt)
-          {
-            int j = len - 1;
-            pt1 = new IntPoint((cInt)Round(m_srcPoly[j].X + m_normals[j].X *
-              delta), (cInt)Round(m_srcPoly[j].Y + m_normals[j].Y * delta));
-            m_destPoly.Add(pt1);
-            pt1 = new IntPoint((cInt)Round(m_srcPoly[j].X - m_normals[j].X *
-              delta), (cInt)Round(m_srcPoly[j].Y - m_normals[j].Y * delta));
-            m_destPoly.Add(pt1);
-          }
-          else
-          {
-            int j = len - 1;
-            k = len - 2;
-            m_sinA = 0;
-            m_normals[j] = new DoublePoint(-m_normals[j].X, -m_normals[j].Y);
-            if (node.MEndtype == EndType.etOpenSquare)
-              DoSquare(j, k);
+            //if this path's lowest pt is lower than all the others then update m_lowest
+            if (endType != EndType.etClosedPolygon) return;
+            if (m_lowest.X < 0)
+                m_lowest = new IntPoint(m_polyNodes.ChildCount - 1, k);
             else
-              DoRound(j, k);
-          }
-
-          //re-build m_normals ...
-          for (int j = len - 1; j > 0; j--)
-            m_normals[j] = new DoublePoint(-m_normals[j - 1].X, -m_normals[j - 1].Y);
-
-          m_normals[0] = new DoublePoint(-m_normals[1].X, -m_normals[1].Y);
-
-          k = len - 1;
-          for (int j = k - 1; j > 0; --j)
-            OffsetPoint(j, ref k, node.MJointype);
-
-          if (node.MEndtype == EndType.etOpenButt)
-          {
-            pt1 = new IntPoint((cInt)Round(m_srcPoly[0].X - m_normals[0].X * delta),
-              (cInt)Round(m_srcPoly[0].Y - m_normals[0].Y * delta));
-            m_destPoly.Add(pt1);
-            pt1 = new IntPoint((cInt)Round(m_srcPoly[0].X + m_normals[0].X * delta),
-              (cInt)Round(m_srcPoly[0].Y + m_normals[0].Y * delta));
-            m_destPoly.Add(pt1);
-          }
-          else
-          {
-            k = 1;
-            m_sinA = 0;
-            if (node.MEndtype == EndType.etOpenSquare)
-              DoSquare(0, 1);
-            else
-              DoRound(0, 1);
-          }
-          m_destPolys.Add(m_destPoly);
-        }
-      }
-    }
-    //------------------------------------------------------------------------------
-
-    internal void Execute(ref Paths solution, double delta)
-    {
-      solution.Clear();
-      FixOrientations();
-      DoOffset(delta);
-      //now clean up 'corners' ...
-      Clipper clpr = new Clipper();
-      clpr.AddPaths(m_destPolys, PolyType.ptSubject, true);
-      if (delta > 0)
-      {
-        clpr.Execute(ClipType.ctUnion, solution,
-          PolyFillType.pftPositive, PolyFillType.pftPositive);
-      }
-      else
-      {
-        IntRect r = Clipper.GetBounds(m_destPolys);
-        Path outer = new Path(4);
-
-        outer.Add(new IntPoint(r.left - 10, r.bottom + 10));
-        outer.Add(new IntPoint(r.right + 10, r.bottom + 10));
-        outer.Add(new IntPoint(r.right + 10, r.top - 10));
-        outer.Add(new IntPoint(r.left - 10, r.top - 10));
-
-        clpr.AddPath(outer, PolyType.ptSubject, true);
-        clpr.ReverseSolution = true;
-        clpr.Execute(ClipType.ctUnion, solution, PolyFillType.pftNegative, PolyFillType.pftNegative);
-        if (solution.Count > 0) solution.RemoveAt(0);
-      }
-    }
-    //------------------------------------------------------------------------------
-
-    internal void Execute(ref PolyTree solution, double delta)
-    {
-      solution.Clear();
-      FixOrientations();
-      DoOffset(delta);
-
-      //now clean up 'corners' ...
-      Clipper clpr = new Clipper();
-      clpr.AddPaths(m_destPolys, PolyType.ptSubject, true);
-      if (delta > 0)
-      {
-        clpr.Execute(ClipType.ctUnion, solution,
-          PolyFillType.pftPositive, PolyFillType.pftPositive);
-      }
-      else
-      {
-        IntRect r = Clipper.GetBounds(m_destPolys);
-        Path outer = new Path(4);
-
-        outer.Add(new IntPoint(r.left - 10, r.bottom + 10));
-        outer.Add(new IntPoint(r.right + 10, r.bottom + 10));
-        outer.Add(new IntPoint(r.right + 10, r.top - 10));
-        outer.Add(new IntPoint(r.left - 10, r.top - 10));
-
-        clpr.AddPath(outer, PolyType.ptSubject, true);
-        clpr.ReverseSolution = true;
-        clpr.Execute(ClipType.ctUnion, solution, PolyFillType.pftNegative, PolyFillType.pftNegative);
-        //remove the outer PolyNode rectangle ...
-        if (solution.ChildCount == 1 && solution.Childs[0].ChildCount > 0)
-        {
-          PolyNode outerNode = solution.Childs[0];
-          solution.Childs.Capacity = outerNode.ChildCount;
-          solution.Childs[0] = outerNode.Childs[0];
-          solution.Childs[0].MParent = solution;
-          for (int i = 1; i < outerNode.ChildCount; i++)
-            solution.AddChild(outerNode.Childs[i]);
-        }
-        else
-          solution.Clear();
-      }
-    }
-    //------------------------------------------------------------------------------
-
-    void OffsetPoint(int j, ref int k, JoinType jointype)
-    {
-      //cross product ...
-      m_sinA = (m_normals[k].X * m_normals[j].Y - m_normals[j].X * m_normals[k].Y);
-
-      if (Math.Abs(m_sinA * m_delta) < 1.0) 
-      {
-        //dot product ...
-        double cosA = (m_normals[k].X * m_normals[j].X + m_normals[j].Y * m_normals[k].Y); 
-        if (cosA > 0) // angle ==> 0 degrees
-        {
-          m_destPoly.Add(new IntPoint(Round(m_srcPoly[j].X + m_normals[k].X * m_delta),
-            Round(m_srcPoly[j].Y + m_normals[k].Y * m_delta)));
-          return; 
-        }
-        //else angle ==> 180 degrees   
-      }
-      else if (m_sinA > 1.0) m_sinA = 1.0;
-      else if (m_sinA < -1.0) m_sinA = -1.0;
-      
-      if (m_sinA * m_delta < 0)
-      {
-        m_destPoly.Add(new IntPoint(Round(m_srcPoly[j].X + m_normals[k].X * m_delta),
-          Round(m_srcPoly[j].Y + m_normals[k].Y * m_delta)));
-        m_destPoly.Add(m_srcPoly[j]);
-        m_destPoly.Add(new IntPoint(Round(m_srcPoly[j].X + m_normals[j].X * m_delta),
-          Round(m_srcPoly[j].Y + m_normals[j].Y * m_delta)));
-      }
-      else
-        switch (jointype)
-        {
-          case JoinType.jtMiter:
             {
-              double r = 1 + (m_normals[j].X * m_normals[k].X +
-                m_normals[j].Y * m_normals[k].Y);
-              if (r >= m_miterLim) DoMiter(j, k, r); else DoSquare(j, k);
-              break;
+                IntPoint ip = m_polyNodes.Childs[(int)m_lowest.X].MPolygon[(int)m_lowest.Y];
+                if (newNode.MPolygon[k].Y > ip.Y ||
+                  (newNode.MPolygon[k].Y == ip.Y &&
+                  newNode.MPolygon[k].X < ip.X))
+                    m_lowest = new IntPoint(m_polyNodes.ChildCount - 1, k);
             }
-          case JoinType.jtSquare: DoSquare(j, k); break;
-          case JoinType.jtRound: DoRound(j, k); break;
         }
-      k = j;
-    }
-    //------------------------------------------------------------------------------
+        //------------------------------------------------------------------------------
 
-    internal void DoSquare(int j, int k)
-    {
-      double dx = Math.Tan(Math.Atan2(m_sinA,
-          m_normals[k].X * m_normals[j].X + m_normals[k].Y * m_normals[j].Y) / 4);
-      m_destPoly.Add(new IntPoint(
-          Round(m_srcPoly[j].X + m_delta * (m_normals[k].X - m_normals[k].Y * dx)),
-          Round(m_srcPoly[j].Y + m_delta * (m_normals[k].Y + m_normals[k].X * dx))));
-      m_destPoly.Add(new IntPoint(
-          Round(m_srcPoly[j].X + m_delta * (m_normals[j].X + m_normals[j].Y * dx)),
-          Round(m_srcPoly[j].Y + m_delta * (m_normals[j].Y - m_normals[j].X * dx))));
-    }
-    //------------------------------------------------------------------------------
+        internal void AddPaths(Paths paths, JoinType joinType, EndType endType)
+        {
+            foreach (Path p in paths)
+                AddPath(p, joinType, endType);
+        }
+        //------------------------------------------------------------------------------
 
-    internal void DoMiter(int j, int k, double r)
-    {
-      double q = m_delta / r;
-      m_destPoly.Add(new IntPoint(Round(m_srcPoly[j].X + (m_normals[k].X + m_normals[j].X) * q),
-          Round(m_srcPoly[j].Y + (m_normals[k].Y + m_normals[j].Y) * q)));
-    }
-    //------------------------------------------------------------------------------
+        private void FixOrientations()
+        {
+            //fixup orientations of all closed paths if the orientation of the
+            //closed path with the lowermost vertex is wrong ...
+            if (m_lowest.X >= 0 &&
+              !Clipper.Orientation(m_polyNodes.Childs[(int)m_lowest.X].MPolygon))
+            {
+                for (int i = 0; i < m_polyNodes.ChildCount; i++)
+                {
+                    PolyNode node = m_polyNodes.Childs[i];
+                    if (node.MEndtype == EndType.etClosedPolygon ||
+                      (node.MEndtype == EndType.etClosedLine &&
+                      Clipper.Orientation(node.MPolygon)))
+                        node.MPolygon.Reverse();
+                }
+            }
+            else
+            {
+                for (int i = 0; i < m_polyNodes.ChildCount; i++)
+                {
+                    PolyNode node = m_polyNodes.Childs[i];
+                    if (node.MEndtype == EndType.etClosedLine &&
+                      !Clipper.Orientation(node.MPolygon))
+                        node.MPolygon.Reverse();
+                }
+            }
+        }
+        //------------------------------------------------------------------------------
 
-    internal void DoRound(int j, int k)
-    {
-      double a = Math.Atan2(m_sinA,
-      m_normals[k].X * m_normals[j].X + m_normals[k].Y * m_normals[j].Y);
-      int steps = Math.Max((int)Round(m_StepsPerRad * Math.Abs(a)),1);
+        internal static DoublePoint GetUnitNormal(IntPoint pt1, IntPoint pt2)
+        {
+            double dx = (pt2.X - pt1.X);
+            double dy = (pt2.Y - pt1.Y);
+            if ((dx == 0) && (dy == 0)) return new DoublePoint();
 
-      double X = m_normals[k].X, Y = m_normals[k].Y, X2;
-      for (int i = 0; i < steps; ++i)
-      {
-        m_destPoly.Add(new IntPoint(
-            Round(m_srcPoly[j].X + X * m_delta),
-            Round(m_srcPoly[j].Y + Y * m_delta)));
-        X2 = X;
-        X = X * m_cos - m_sin * Y;
-        Y = X2 * m_sin + Y * m_cos;
-      }
-      m_destPoly.Add(new IntPoint(
-      Round(m_srcPoly[j].X + m_normals[j].X * m_delta),
-      Round(m_srcPoly[j].Y + m_normals[j].Y * m_delta)));
+            double f = 1 * 1.0 / Math.Sqrt(dx * dx + dy * dy);
+            dx *= f;
+            dy *= f;
+
+            return new DoublePoint(dy, -dx);
+        }
+        //------------------------------------------------------------------------------
+
+        private void DoOffset(double delta)
+        {
+            m_destPolys = new Paths();
+            m_delta = delta;
+
+            //if Zero offset, just copy any CLOSED polygons to m_p and return ...
+            if (ClipperBase.near_zero(delta))
+            {
+                m_destPolys.Capacity = m_polyNodes.ChildCount;
+                for (int i = 0; i < m_polyNodes.ChildCount; i++)
+                {
+                    PolyNode node = m_polyNodes.Childs[i];
+                    if (node.MEndtype == EndType.etClosedPolygon)
+                        m_destPolys.Add(node.MPolygon);
+                }
+                return;
+            }
+
+            //see offset_triginometry3.svg in the documentation folder ...
+            if (MiterLimit > 2) m_miterLim = 2 / (MiterLimit * MiterLimit);
+            else m_miterLim = 0.5;
+
+            double y;
+            if (ArcTolerance <= 0.0)
+                y = def_arc_tolerance;
+            else if (ArcTolerance > Math.Abs(delta) * def_arc_tolerance)
+                y = Math.Abs(delta) * def_arc_tolerance;
+            else
+                y = ArcTolerance;
+            //see offset_triginometry2.svg in the documentation folder ...
+            double steps = Math.PI / Math.Acos(1 - y / Math.Abs(delta));
+            m_sin = Math.Sin(two_pi / steps);
+            m_cos = Math.Cos(two_pi / steps);
+            m_StepsPerRad = steps / two_pi;
+            if (delta < 0.0) m_sin = -m_sin;
+
+            m_destPolys.Capacity = m_polyNodes.ChildCount * 2;
+            for (int i = 0; i < m_polyNodes.ChildCount; i++)
+            {
+                PolyNode node = m_polyNodes.Childs[i];
+                m_srcPoly = node.MPolygon;
+
+                int len = m_srcPoly.Count;
+
+                if (len == 0 || (delta <= 0 && (len < 3 ||
+                  node.MEndtype != EndType.etClosedPolygon)))
+                    continue;
+
+                m_destPoly = new Path();
+
+                if (len == 1)
+                {
+                    if (node.MJointype == JoinType.jtRound)
+                    {
+                        double X = 1.0, Y = 0.0;
+                        for (int j = 1; j <= steps; j++)
+                        {
+                            m_destPoly.Add(new IntPoint(
+                              Round(m_srcPoly[0].X + X * delta),
+                              Round(m_srcPoly[0].Y + Y * delta)));
+                            double X2 = X;
+                            X = X * m_cos - m_sin * Y;
+                            Y = X2 * m_sin + Y * m_cos;
+                        }
+                    }
+                    else
+                    {
+                        double X = -1.0, Y = -1.0;
+                        for (int j = 0; j < 4; ++j)
+                        {
+                            m_destPoly.Add(new IntPoint(
+                              Round(m_srcPoly[0].X + X * delta),
+                              Round(m_srcPoly[0].Y + Y * delta)));
+                            if (X < 0) X = 1;
+                            else if (Y < 0) Y = 1;
+                            else X = -1;
+                        }
+                    }
+                    m_destPolys.Add(m_destPoly);
+                    continue;
+                }
+
+                //build m_normals ...
+                m_normals.Clear();
+                m_normals.Capacity = len;
+                for (int j = 0; j < len - 1; j++)
+                    m_normals.Add(GetUnitNormal(m_srcPoly[j], m_srcPoly[j + 1]));
+                if (node.MEndtype == EndType.etClosedLine ||
+                  node.MEndtype == EndType.etClosedPolygon)
+                    m_normals.Add(GetUnitNormal(m_srcPoly[len - 1], m_srcPoly[0]));
+                else
+                    m_normals.Add(new DoublePoint(m_normals[len - 2]));
+
+                if (node.MEndtype == EndType.etClosedPolygon)
+                {
+                    int k = len - 1;
+                    for (int j = 0; j < len; j++)
+                        OffsetPoint(j, ref k, node.MJointype);
+                    m_destPolys.Add(m_destPoly);
+                }
+                else if (node.MEndtype == EndType.etClosedLine)
+                {
+                    int k = len - 1;
+                    for (int j = 0; j < len; j++)
+                        OffsetPoint(j, ref k, node.MJointype);
+                    m_destPolys.Add(m_destPoly);
+                    m_destPoly = new Path();
+                    //re-build m_normals ...
+                    DoublePoint n = m_normals[len - 1];
+                    for (int j = len - 1; j > 0; j--)
+                        m_normals[j] = new DoublePoint(-m_normals[j - 1].X, -m_normals[j - 1].Y);
+                    m_normals[0] = new DoublePoint(-n.X, -n.Y);
+                    k = 0;
+                    for (int j = len - 1; j >= 0; j--)
+                        OffsetPoint(j, ref k, node.MJointype);
+                    m_destPolys.Add(m_destPoly);
+                }
+                else
+                {
+                    int k = 0;
+                    for (int j = 1; j < len - 1; ++j)
+                        OffsetPoint(j, ref k, node.MJointype);
+
+                    IntPoint pt1;
+                    if (node.MEndtype == EndType.etOpenButt)
+                    {
+                        int j = len - 1;
+                        pt1 = new IntPoint((cInt)Round(m_srcPoly[j].X + m_normals[j].X *
+                          delta), (cInt)Round(m_srcPoly[j].Y + m_normals[j].Y * delta));
+                        m_destPoly.Add(pt1);
+                        pt1 = new IntPoint((cInt)Round(m_srcPoly[j].X - m_normals[j].X *
+                          delta), (cInt)Round(m_srcPoly[j].Y - m_normals[j].Y * delta));
+                        m_destPoly.Add(pt1);
+                    }
+                    else
+                    {
+                        int j = len - 1;
+                        k = len - 2;
+                        m_sinA = 0;
+                        m_normals[j] = new DoublePoint(-m_normals[j].X, -m_normals[j].Y);
+                        if (node.MEndtype == EndType.etOpenSquare)
+                            DoSquare(j, k);
+                        else
+                            DoRound(j, k);
+                    }
+
+                    //re-build m_normals ...
+                    for (int j = len - 1; j > 0; j--)
+                        m_normals[j] = new DoublePoint(-m_normals[j - 1].X, -m_normals[j - 1].Y);
+
+                    m_normals[0] = new DoublePoint(-m_normals[1].X, -m_normals[1].Y);
+
+                    k = len - 1;
+                    for (int j = k - 1; j > 0; --j)
+                        OffsetPoint(j, ref k, node.MJointype);
+
+                    if (node.MEndtype == EndType.etOpenButt)
+                    {
+                        pt1 = new IntPoint((cInt)Round(m_srcPoly[0].X - m_normals[0].X * delta),
+                          (cInt)Round(m_srcPoly[0].Y - m_normals[0].Y * delta));
+                        m_destPoly.Add(pt1);
+                        pt1 = new IntPoint((cInt)Round(m_srcPoly[0].X + m_normals[0].X * delta),
+                          (cInt)Round(m_srcPoly[0].Y + m_normals[0].Y * delta));
+                        m_destPoly.Add(pt1);
+                    }
+                    else
+                    {
+                        k = 1;
+                        m_sinA = 0;
+                        if (node.MEndtype == EndType.etOpenSquare)
+                            DoSquare(0, 1);
+                        else
+                            DoRound(0, 1);
+                    }
+                    m_destPolys.Add(m_destPoly);
+                }
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        internal void Execute(ref Paths solution, double delta)
+        {
+            solution.Clear();
+            FixOrientations();
+            DoOffset(delta);
+            //now clean up 'corners' ...
+            Clipper clpr = new Clipper();
+            clpr.AddPaths(m_destPolys, PolyType.ptSubject, true);
+            if (delta > 0)
+            {
+                clpr.Execute(ClipType.ctUnion, solution,
+                  PolyFillType.pftPositive, PolyFillType.pftPositive);
+            }
+            else
+            {
+                IntRect r = Clipper.GetBounds(m_destPolys);
+                Path outer = new Path(4);
+
+                outer.Add(new IntPoint(r.left - 10, r.bottom + 10));
+                outer.Add(new IntPoint(r.right + 10, r.bottom + 10));
+                outer.Add(new IntPoint(r.right + 10, r.top - 10));
+                outer.Add(new IntPoint(r.left - 10, r.top - 10));
+
+                clpr.AddPath(outer, PolyType.ptSubject, true);
+                clpr.ReverseSolution = true;
+                clpr.Execute(ClipType.ctUnion, solution, PolyFillType.pftNegative, PolyFillType.pftNegative);
+                if (solution.Count > 0) solution.RemoveAt(0);
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        internal void Execute(ref PolyTree solution, double delta)
+        {
+            solution.Clear();
+            FixOrientations();
+            DoOffset(delta);
+
+            //now clean up 'corners' ...
+            Clipper clpr = new Clipper();
+            clpr.AddPaths(m_destPolys, PolyType.ptSubject, true);
+            if (delta > 0)
+            {
+                clpr.Execute(ClipType.ctUnion, solution,
+                  PolyFillType.pftPositive, PolyFillType.pftPositive);
+            }
+            else
+            {
+                IntRect r = Clipper.GetBounds(m_destPolys);
+                Path outer = new Path(4);
+
+                outer.Add(new IntPoint(r.left - 10, r.bottom + 10));
+                outer.Add(new IntPoint(r.right + 10, r.bottom + 10));
+                outer.Add(new IntPoint(r.right + 10, r.top - 10));
+                outer.Add(new IntPoint(r.left - 10, r.top - 10));
+
+                clpr.AddPath(outer, PolyType.ptSubject, true);
+                clpr.ReverseSolution = true;
+                clpr.Execute(ClipType.ctUnion, solution, PolyFillType.pftNegative, PolyFillType.pftNegative);
+                //remove the outer PolyNode rectangle ...
+                if (solution.ChildCount == 1 && solution.Childs[0].ChildCount > 0)
+                {
+                    PolyNode outerNode = solution.Childs[0];
+                    solution.Childs.Capacity = outerNode.ChildCount;
+                    solution.Childs[0] = outerNode.Childs[0];
+                    solution.Childs[0].MParent = solution;
+                    for (int i = 1; i < outerNode.ChildCount; i++)
+                        solution.AddChild(outerNode.Childs[i]);
+                }
+                else
+                    solution.Clear();
+            }
+        }
+        //------------------------------------------------------------------------------
+
+        void OffsetPoint(int j, ref int k, JoinType jointype)
+        {
+            //cross product ...
+            m_sinA = (m_normals[k].X * m_normals[j].Y - m_normals[j].X * m_normals[k].Y);
+
+            if (Math.Abs(m_sinA * m_delta) < 1.0)
+            {
+                //dot product ...
+                double cosA = (m_normals[k].X * m_normals[j].X + m_normals[j].Y * m_normals[k].Y);
+                if (cosA > 0) // angle ==> 0 degrees
+                {
+                    m_destPoly.Add(new IntPoint(Round(m_srcPoly[j].X + m_normals[k].X * m_delta),
+                      Round(m_srcPoly[j].Y + m_normals[k].Y * m_delta)));
+                    return;
+                }
+                //else angle ==> 180 degrees   
+            }
+            else if (m_sinA > 1.0) m_sinA = 1.0;
+            else if (m_sinA < -1.0) m_sinA = -1.0;
+
+            if (m_sinA * m_delta < 0)
+            {
+                m_destPoly.Add(new IntPoint(Round(m_srcPoly[j].X + m_normals[k].X * m_delta),
+                  Round(m_srcPoly[j].Y + m_normals[k].Y * m_delta)));
+                m_destPoly.Add(m_srcPoly[j]);
+                m_destPoly.Add(new IntPoint(Round(m_srcPoly[j].X + m_normals[j].X * m_delta),
+                  Round(m_srcPoly[j].Y + m_normals[j].Y * m_delta)));
+            }
+            else
+                switch (jointype)
+                {
+                    case JoinType.jtMiter:
+                        {
+                            double r = 1 + (m_normals[j].X * m_normals[k].X +
+                              m_normals[j].Y * m_normals[k].Y);
+                            if (r >= m_miterLim) DoMiter(j, k, r); else DoSquare(j, k);
+                            break;
+                        }
+                    case JoinType.jtSquare: DoSquare(j, k); break;
+                    case JoinType.jtRound: DoRound(j, k); break;
+                }
+            k = j;
+        }
+        //------------------------------------------------------------------------------
+
+        internal void DoSquare(int j, int k)
+        {
+            double dx = Math.Tan(Math.Atan2(m_sinA,
+                m_normals[k].X * m_normals[j].X + m_normals[k].Y * m_normals[j].Y) / 4);
+            m_destPoly.Add(new IntPoint(
+                Round(m_srcPoly[j].X + m_delta * (m_normals[k].X - m_normals[k].Y * dx)),
+                Round(m_srcPoly[j].Y + m_delta * (m_normals[k].Y + m_normals[k].X * dx))));
+            m_destPoly.Add(new IntPoint(
+                Round(m_srcPoly[j].X + m_delta * (m_normals[j].X + m_normals[j].Y * dx)),
+                Round(m_srcPoly[j].Y + m_delta * (m_normals[j].Y - m_normals[j].X * dx))));
+        }
+        //------------------------------------------------------------------------------
+
+        internal void DoMiter(int j, int k, double r)
+        {
+            double q = m_delta / r;
+            m_destPoly.Add(new IntPoint(Round(m_srcPoly[j].X + (m_normals[k].X + m_normals[j].X) * q),
+                Round(m_srcPoly[j].Y + (m_normals[k].Y + m_normals[j].Y) * q)));
+        }
+        //------------------------------------------------------------------------------
+
+        internal void DoRound(int j, int k)
+        {
+            double a = Math.Atan2(m_sinA,
+            m_normals[k].X * m_normals[j].X + m_normals[k].Y * m_normals[j].Y);
+            int steps = Math.Max((int)Round(m_StepsPerRad * Math.Abs(a)), 1);
+
+            double X = m_normals[k].X, Y = m_normals[k].Y, X2;
+            for (int i = 0; i < steps; ++i)
+            {
+                m_destPoly.Add(new IntPoint(
+                    Round(m_srcPoly[j].X + X * m_delta),
+                    Round(m_srcPoly[j].Y + Y * m_delta)));
+                X2 = X;
+                X = X * m_cos - m_sin * Y;
+                Y = X2 * m_sin + Y * m_cos;
+            }
+            m_destPoly.Add(new IntPoint(
+            Round(m_srcPoly[j].X + m_normals[j].X * m_delta),
+            Round(m_srcPoly[j].Y + m_normals[j].Y * m_delta)));
+        }
+        //------------------------------------------------------------------------------
     }
-    //------------------------------------------------------------------------------
-  }
     #endregion
 
     internal class ClipperException : Exception
     {
-        internal ClipperException(string description) : base(description){}
+        internal ClipperException(string description) : base(description) { }
     }
 } //end ClipperLib namespace

--- a/TessellationAndVoxelizationGeometryLibrary/Boolean Operations/PolygonOperations.cs
+++ b/TessellationAndVoxelizationGeometryLibrary/Boolean Operations/PolygonOperations.cs
@@ -105,7 +105,7 @@ namespace TVGL.Boolean_Operations
             //Begin an evaluation
             var solution = new List<List<IntPoint>>();
             var clip = new ClipperOffset();
-            clip.AddPaths(polygons, JoinType.jtRound, EndType.etClosedPolygon);
+            clip.AddPaths(polygons, JoinType.Round, EndType.ClosedPolygon);
             clip.Execute(ref solution, offset * scale);
 
             var offsetLoops = new List<List<Point>>();
@@ -481,20 +481,20 @@ namespace TVGL.Boolean_Operations.Clipper
     #endregion
 
     #region Internal Enum Values
-    internal enum ClipType { ctIntersection, ctUnion, ctDifference, ctXor };
-    internal enum PolyType { ptSubject, ptClip };
+    internal enum ClipType { Intersection, Union, Difference, Xor };
+    internal enum PolyType { Subject, Clip };
 
     //By far the most widely used winding rules for polygon filling are
     //EvenOdd & NonZero (GDI, GDI+, XLib, OpenGL, Cairo, AGG, Quartz, SVG, Gr32)
     //Others rules include Positive, Negative and ABS_GTR_EQ_TWO (only in OpenGL)
     //see http://glprogramming.com/red/chapter11.html
-    internal enum PolyFillType { pftEvenOdd, pftNonZero, pftPositive, pftNegative };
+    internal enum PolyFillType { EvenOdd, NonZero, Positive, Negative };
 
-    internal enum JoinType { jtSquare, jtRound, jtMiter };
-    internal enum EndType { etClosedPolygon, etClosedLine, etOpenButt, etOpenSquare, etOpenRound };
+    internal enum JoinType { Square, Round, Miter };
+    internal enum EndType { ClosedPolygon, ClosedLine, OpenButt, OpenSquare, OpenRound };
 
-    internal enum EdgeSide { esLeft, esRight };
-    internal enum Direction { dRightToLeft, dLeftToRight };
+    internal enum EdgeSide { Left, Right };
+    internal enum Direction { RightToLeft, LeftToRight };
     #endregion
 
     #region T Edge Class
@@ -916,7 +916,7 @@ namespace TVGL.Boolean_Operations.Clipper
         internal bool AddPath(Path pg, PolyType polyType, bool Closed)
         {
 #if use_lines
-      if (!Closed && polyType == PolyType.ptClip)
+      if (!Closed && polyType == PolyType.Clip)
         throw new ClipperException("AddPath: Open paths must be subject.");
 #else
             if (!Closed)
@@ -1014,7 +1014,7 @@ namespace TVGL.Boolean_Operations.Clipper
                 locMin.Y = E.Bot.Y;
                 locMin.LeftBound = null;
                 locMin.RightBound = E;
-                locMin.RightBound.Side = EdgeSide.esRight;
+                locMin.RightBound.Side = EdgeSide.Right;
                 locMin.RightBound.WindDelta = 0;
                 while (E.Next.OutIdx != Skip)
                 {
@@ -1058,8 +1058,8 @@ namespace TVGL.Boolean_Operations.Clipper
                     locMin.RightBound = E.Prev;
                     leftBoundIsForward = true; //Q.nextInLML = Q.next
                 }
-                locMin.LeftBound.Side = EdgeSide.esLeft;
-                locMin.RightBound.Side = EdgeSide.esRight;
+                locMin.LeftBound.Side = EdgeSide.Left;
+                locMin.RightBound.Side = EdgeSide.Right;
 
                 if (!Closed) locMin.LeftBound.WindDelta = 0;
                 else if (locMin.LeftBound.Next == locMin.RightBound)
@@ -1176,14 +1176,14 @@ namespace TVGL.Boolean_Operations.Clipper
                 if (e != null)
                 {
                     e.Curr = e.Bot;
-                    e.Side = EdgeSide.esLeft;
+                    e.Side = EdgeSide.Left;
                     e.OutIdx = Unassigned;
                 }
                 e = lm.RightBound;
                 if (e != null)
                 {
                     e.Curr = e.Bot;
-                    e.Side = EdgeSide.esRight;
+                    e.Side = EdgeSide.Right;
                     e.OutIdx = Unassigned;
                 }
                 lm = lm.Next;
@@ -1387,14 +1387,14 @@ namespace TVGL.Boolean_Operations.Clipper
         internal bool Execute(ClipType clipType, Paths solution)
         {
             return Execute(clipType, solution,
-                PolyFillType.pftEvenOdd, PolyFillType.pftEvenOdd);
+                PolyFillType.EvenOdd, PolyFillType.EvenOdd);
         }
         //------------------------------------------------------------------------------
 
         internal bool Execute(ClipType clipType, PolyTree polytree)
         {
             return Execute(clipType, polytree,
-                PolyFillType.pftEvenOdd, PolyFillType.pftEvenOdd);
+                PolyFillType.EvenOdd, PolyFillType.EvenOdd);
         }
         //------------------------------------------------------------------------------
 
@@ -1657,26 +1657,26 @@ namespace TVGL.Boolean_Operations.Clipper
 
         private bool IsEvenOddFillType(TEdge edge)
         {
-            if (edge.PolyTyp == PolyType.ptSubject)
-                return m_SubjFillType == PolyFillType.pftEvenOdd;
+            if (edge.PolyTyp == PolyType.Subject)
+                return m_SubjFillType == PolyFillType.EvenOdd;
             else
-                return m_ClipFillType == PolyFillType.pftEvenOdd;
+                return m_ClipFillType == PolyFillType.EvenOdd;
         }
         //------------------------------------------------------------------------------
 
         private bool IsEvenOddAltFillType(TEdge edge)
         {
-            if (edge.PolyTyp == PolyType.ptSubject)
-                return m_ClipFillType == PolyFillType.pftEvenOdd;
+            if (edge.PolyTyp == PolyType.Subject)
+                return m_ClipFillType == PolyFillType.EvenOdd;
             else
-                return m_SubjFillType == PolyFillType.pftEvenOdd;
+                return m_SubjFillType == PolyFillType.EvenOdd;
         }
         //------------------------------------------------------------------------------
 
         private bool IsContributing(TEdge edge)
         {
             PolyFillType pft, pft2;
-            if (edge.PolyTyp == PolyType.ptSubject)
+            if (edge.PolyTyp == PolyType.Subject)
             {
                 pft = m_SubjFillType;
                 pft2 = m_ClipFillType;
@@ -1689,14 +1689,14 @@ namespace TVGL.Boolean_Operations.Clipper
 
             switch (pft)
             {
-                case PolyFillType.pftEvenOdd:
+                case PolyFillType.EvenOdd:
                     //return false if a subj line has been flagged as inside a subj polygon
                     if (edge.WindDelta == 0 && edge.WindCnt != 1) return false;
                     break;
-                case PolyFillType.pftNonZero:
+                case PolyFillType.NonZero:
                     if (Math.Abs(edge.WindCnt) != 1) return false;
                     break;
-                case PolyFillType.pftPositive:
+                case PolyFillType.Positive:
                     if (edge.WindCnt != 1) return false;
                     break;
                 default: //PolyFillType.pftNegative
@@ -1706,36 +1706,36 @@ namespace TVGL.Boolean_Operations.Clipper
 
             switch (m_ClipType)
             {
-                case ClipType.ctIntersection:
+                case ClipType.Intersection:
                     switch (pft2)
                     {
-                        case PolyFillType.pftEvenOdd:
-                        case PolyFillType.pftNonZero:
+                        case PolyFillType.EvenOdd:
+                        case PolyFillType.NonZero:
                             return (edge.WindCnt2 != 0);
-                        case PolyFillType.pftPositive:
+                        case PolyFillType.Positive:
                             return (edge.WindCnt2 > 0);
                         default:
                             return (edge.WindCnt2 < 0);
                     }
-                case ClipType.ctUnion:
+                case ClipType.Union:
                     switch (pft2)
                     {
-                        case PolyFillType.pftEvenOdd:
-                        case PolyFillType.pftNonZero:
+                        case PolyFillType.EvenOdd:
+                        case PolyFillType.NonZero:
                             return (edge.WindCnt2 == 0);
-                        case PolyFillType.pftPositive:
+                        case PolyFillType.Positive:
                             return (edge.WindCnt2 <= 0);
                         default:
                             return (edge.WindCnt2 >= 0);
                     }
-                case ClipType.ctDifference:
-                    if (edge.PolyTyp == PolyType.ptSubject)
+                case ClipType.Difference:
+                    if (edge.PolyTyp == PolyType.Subject)
                         switch (pft2)
                         {
-                            case PolyFillType.pftEvenOdd:
-                            case PolyFillType.pftNonZero:
+                            case PolyFillType.EvenOdd:
+                            case PolyFillType.NonZero:
                                 return (edge.WindCnt2 == 0);
-                            case PolyFillType.pftPositive:
+                            case PolyFillType.Positive:
                                 return (edge.WindCnt2 <= 0);
                             default:
                                 return (edge.WindCnt2 >= 0);
@@ -1743,22 +1743,22 @@ namespace TVGL.Boolean_Operations.Clipper
                     else
                         switch (pft2)
                         {
-                            case PolyFillType.pftEvenOdd:
-                            case PolyFillType.pftNonZero:
+                            case PolyFillType.EvenOdd:
+                            case PolyFillType.NonZero:
                                 return (edge.WindCnt2 != 0);
-                            case PolyFillType.pftPositive:
+                            case PolyFillType.Positive:
                                 return (edge.WindCnt2 > 0);
                             default:
                                 return (edge.WindCnt2 < 0);
                         }
-                case ClipType.ctXor:
+                case ClipType.Xor:
                     if (edge.WindDelta == 0) //XOr always contributing unless open
                         switch (pft2)
                         {
-                            case PolyFillType.pftEvenOdd:
-                            case PolyFillType.pftNonZero:
+                            case PolyFillType.EvenOdd:
+                            case PolyFillType.NonZero:
                                 return (edge.WindCnt2 == 0);
-                            case PolyFillType.pftPositive:
+                            case PolyFillType.Positive:
                                 return (edge.WindCnt2 <= 0);
                             default:
                                 return (edge.WindCnt2 >= 0);
@@ -1781,7 +1781,7 @@ namespace TVGL.Boolean_Operations.Clipper
                 edge.WindCnt2 = 0;
                 e = m_ActiveEdges; //ie get ready to calc WindCnt2
             }
-            else if (edge.WindDelta == 0 && m_ClipType != ClipType.ctUnion)
+            else if (edge.WindDelta == 0 && m_ClipType != ClipType.Union)
             {
                 edge.WindCnt = 1;
                 edge.WindCnt2 = e.WindCnt2;
@@ -2041,8 +2041,8 @@ namespace TVGL.Boolean_Operations.Clipper
             {
                 result = AddOutPt(e1, pt);
                 e2.OutIdx = e1.OutIdx;
-                e1.Side = EdgeSide.esLeft;
-                e2.Side = EdgeSide.esRight;
+                e1.Side = EdgeSide.Left;
+                e2.Side = EdgeSide.Right;
                 e = e1;
                 if (e.PrevInAEL == e2)
                     prevE = e2.PrevInAEL;
@@ -2053,8 +2053,8 @@ namespace TVGL.Boolean_Operations.Clipper
             {
                 result = AddOutPt(e2, pt);
                 e1.OutIdx = e2.OutIdx;
-                e1.Side = EdgeSide.esRight;
-                e2.Side = EdgeSide.esLeft;
+                e1.Side = EdgeSide.Right;
+                e2.Side = EdgeSide.Left;
                 e = e2;
                 if (e.PrevInAEL == e1)
                     prevE = e1.PrevInAEL;
@@ -2092,7 +2092,7 @@ namespace TVGL.Boolean_Operations.Clipper
 
         private OutPt AddOutPt(TEdge e, IntPoint pt)
         {
-            bool ToFront = (e.Side == EdgeSide.esLeft);
+            bool ToFront = (e.Side == EdgeSide.Left);
             if (e.OutIdx < 0)
             {
                 OutRec outRec = CreateOutRec();
@@ -2290,9 +2290,9 @@ namespace TVGL.Boolean_Operations.Clipper
 
             EdgeSide side;
             //join e2 poly onto e1 poly and delete pointers to e2 ...
-            if (e1.Side == EdgeSide.esLeft)
+            if (e1.Side == EdgeSide.Left)
             {
-                if (e2.Side == EdgeSide.esLeft)
+                if (e2.Side == EdgeSide.Left)
                 {
                     //z y x a b c
                     ReversePolyPtLinks(p2_lft);
@@ -2311,11 +2311,11 @@ namespace TVGL.Boolean_Operations.Clipper
                     p1_rt.Next = p2_lft;
                     outRec1.Pts = p2_lft;
                 }
-                side = EdgeSide.esLeft;
+                side = EdgeSide.Left;
             }
             else
             {
-                if (e2.Side == EdgeSide.esRight)
+                if (e2.Side == EdgeSide.Right)
                 {
                     //a b c z y x
                     ReversePolyPtLinks(p2_lft);
@@ -2332,7 +2332,7 @@ namespace TVGL.Boolean_Operations.Clipper
                     p1_lft.Prev = p2_rt;
                     p2_rt.Next = p1_lft;
                 }
-                side = EdgeSide.esRight;
+                side = EdgeSide.Right;
             }
 
             outRec1.BottomPt = null;
@@ -2421,7 +2421,7 @@ namespace TVGL.Boolean_Operations.Clipper
             if (e1.WindDelta == 0 && e2.WindDelta == 0) return;
             //if intersecting a subj line with a subj poly ...
             else if (e1.PolyTyp == e2.PolyTyp && 
-              e1.WindDelta != e2.WindDelta && m_ClipType == ClipType.ctUnion)
+              e1.WindDelta != e2.WindDelta && m_ClipType == ClipType.Union)
             {
               if (e1.WindDelta == 0)
               {
@@ -2443,13 +2443,13 @@ namespace TVGL.Boolean_Operations.Clipper
             else if (e1.PolyTyp != e2.PolyTyp)
             {
               if ((e1.WindDelta == 0) && Math.Abs(e2.WindCnt) == 1 && 
-                (m_ClipType != ClipType.ctUnion || e2.WindCnt2 == 0))
+                (m_ClipType != ClipType.Union || e2.WindCnt2 == 0))
               {
                 AddOutPt(e1, pt);
                 if (e1Contributing) e1.OutIdx = Unassigned;
               }
               else if ((e2.WindDelta == 0) && (Math.Abs(e1.WindCnt) == 1) && 
-                (m_ClipType != ClipType.ctUnion || e1.WindCnt2 == 0))
+                (m_ClipType != ClipType.Union || e1.WindCnt2 == 0))
               {
                 AddOutPt(e2, pt);
                 if (e2Contributing) e2.OutIdx = Unassigned;
@@ -2486,7 +2486,7 @@ namespace TVGL.Boolean_Operations.Clipper
             }
 
             PolyFillType e1FillType, e2FillType, e1FillType2, e2FillType2;
-            if (e1.PolyTyp == PolyType.ptSubject)
+            if (e1.PolyTyp == PolyType.Subject)
             {
                 e1FillType = m_SubjFillType;
                 e1FillType2 = m_ClipFillType;
@@ -2496,7 +2496,7 @@ namespace TVGL.Boolean_Operations.Clipper
                 e1FillType = m_ClipFillType;
                 e1FillType2 = m_SubjFillType;
             }
-            if (e2.PolyTyp == PolyType.ptSubject)
+            if (e2.PolyTyp == PolyType.Subject)
             {
                 e2FillType = m_SubjFillType;
                 e2FillType2 = m_ClipFillType;
@@ -2510,21 +2510,21 @@ namespace TVGL.Boolean_Operations.Clipper
             int e1Wc, e2Wc;
             switch (e1FillType)
             {
-                case PolyFillType.pftPositive: e1Wc = e1.WindCnt; break;
-                case PolyFillType.pftNegative: e1Wc = -e1.WindCnt; break;
+                case PolyFillType.Positive: e1Wc = e1.WindCnt; break;
+                case PolyFillType.Negative: e1Wc = -e1.WindCnt; break;
                 default: e1Wc = Math.Abs(e1.WindCnt); break;
             }
             switch (e2FillType)
             {
-                case PolyFillType.pftPositive: e2Wc = e2.WindCnt; break;
-                case PolyFillType.pftNegative: e2Wc = -e2.WindCnt; break;
+                case PolyFillType.Positive: e2Wc = e2.WindCnt; break;
+                case PolyFillType.Negative: e2Wc = -e2.WindCnt; break;
                 default: e2Wc = Math.Abs(e2.WindCnt); break;
             }
 
             if (e1Contributing && e2Contributing)
             {
                 if ((e1Wc != 0 && e1Wc != 1) || (e2Wc != 0 && e2Wc != 1) ||
-                  (e1.PolyTyp != e2.PolyTyp && m_ClipType != ClipType.ctXor))
+                  (e1.PolyTyp != e2.PolyTyp && m_ClipType != ClipType.Xor))
                 {
                     AddLocalMaxPoly(e1, e2, pt);
                 }
@@ -2561,14 +2561,14 @@ namespace TVGL.Boolean_Operations.Clipper
                 cInt e1Wc2, e2Wc2;
                 switch (e1FillType2)
                 {
-                    case PolyFillType.pftPositive: e1Wc2 = e1.WindCnt2; break;
-                    case PolyFillType.pftNegative: e1Wc2 = -e1.WindCnt2; break;
+                    case PolyFillType.Positive: e1Wc2 = e1.WindCnt2; break;
+                    case PolyFillType.Negative: e1Wc2 = -e1.WindCnt2; break;
                     default: e1Wc2 = Math.Abs(e1.WindCnt2); break;
                 }
                 switch (e2FillType2)
                 {
-                    case PolyFillType.pftPositive: e2Wc2 = e2.WindCnt2; break;
-                    case PolyFillType.pftNegative: e2Wc2 = -e2.WindCnt2; break;
+                    case PolyFillType.Positive: e2Wc2 = e2.WindCnt2; break;
+                    case PolyFillType.Negative: e2Wc2 = -e2.WindCnt2; break;
                     default: e2Wc2 = Math.Abs(e2.WindCnt2); break;
                 }
 
@@ -2579,20 +2579,20 @@ namespace TVGL.Boolean_Operations.Clipper
                 else if (e1Wc == 1 && e2Wc == 1)
                     switch (m_ClipType)
                     {
-                        case ClipType.ctIntersection:
+                        case ClipType.Intersection:
                             if (e1Wc2 > 0 && e2Wc2 > 0)
                                 AddLocalMinPoly(e1, e2, pt);
                             break;
-                        case ClipType.ctUnion:
+                        case ClipType.Union:
                             if (e1Wc2 <= 0 && e2Wc2 <= 0)
                                 AddLocalMinPoly(e1, e2, pt);
                             break;
-                        case ClipType.ctDifference:
-                            if (((e1.PolyTyp == PolyType.ptClip) && (e1Wc2 > 0) && (e2Wc2 > 0)) ||
-                                ((e1.PolyTyp == PolyType.ptSubject) && (e1Wc2 <= 0) && (e2Wc2 <= 0)))
+                        case ClipType.Difference:
+                            if (((e1.PolyTyp == PolyType.Clip) && (e1Wc2 > 0) && (e2Wc2 > 0)) ||
+                                ((e1.PolyTyp == PolyType.Subject) && (e1Wc2 <= 0) && (e2Wc2 <= 0)))
                                 AddLocalMinPoly(e1, e2, pt);
                             break;
-                        case ClipType.ctXor:
+                        case ClipType.Xor:
                             AddLocalMinPoly(e1, e2, pt);
                             break;
                     }
@@ -2676,13 +2676,13 @@ namespace TVGL.Boolean_Operations.Clipper
             {
                 Left = HorzEdge.Bot.X;
                 Right = HorzEdge.Top.X;
-                Dir = Direction.dLeftToRight;
+                Dir = Direction.LeftToRight;
             }
             else
             {
                 Left = HorzEdge.Top.X;
                 Right = HorzEdge.Bot.X;
-                Dir = Direction.dRightToLeft;
+                Dir = Direction.RightToLeft;
             }
         }
         //------------------------------------------------------------------------
@@ -2713,8 +2713,8 @@ namespace TVGL.Boolean_Operations.Clipper
 
                     TEdge eNext = GetNextInAEL(e, dir); //saves eNext for later
 
-                    if ((dir == Direction.dLeftToRight && e.Curr.X <= horzRight) ||
-                      (dir == Direction.dRightToLeft && e.Curr.X >= horzLeft))
+                    if ((dir == Direction.LeftToRight && e.Curr.X <= horzRight) ||
+                      (dir == Direction.RightToLeft && e.Curr.X >= horzLeft))
                     {
                         //so far we're still in range of the horizontal Edge  but make sure
                         //we're at the last of consec. horizontals when matching with eMaxPair
@@ -2742,7 +2742,7 @@ namespace TVGL.Boolean_Operations.Clipper
                             DeleteFromAEL(eMaxPair);
                             return;
                         }
-                        else if (dir == Direction.dLeftToRight)
+                        else if (dir == Direction.LeftToRight)
                         {
                             IntPoint Pt = new IntPoint(e.Curr.X, horzEdge.Curr.Y);
                             IntersectEdges(horzEdge, e, Pt);
@@ -2754,8 +2754,8 @@ namespace TVGL.Boolean_Operations.Clipper
                         }
                         SwapPositionsInAEL(horzEdge, e);
                     }
-                    else if ((dir == Direction.dLeftToRight && e.Curr.X >= horzRight) ||
-                      (dir == Direction.dRightToLeft && e.Curr.X <= horzLeft)) break;
+                    else if ((dir == Direction.LeftToRight && e.Curr.X >= horzRight) ||
+                      (dir == Direction.RightToLeft && e.Curr.X <= horzLeft)) break;
                     e = eNext;
                 } //end while
 
@@ -2811,7 +2811,7 @@ namespace TVGL.Boolean_Operations.Clipper
 
         private TEdge GetNextInAEL(TEdge e, Direction Direction)
         {
-            return Direction == Direction.dLeftToRight ? e.NextInAEL : e.PrevInAEL;
+            return Direction == Direction.LeftToRight ? e.NextInAEL : e.PrevInAEL;
         }
         //------------------------------------------------------------------------------
 
@@ -3387,9 +3387,9 @@ namespace TVGL.Boolean_Operations.Clipper
           IntPoint Pt, bool DiscardLeft)
         {
             Direction Dir1 = (op1.Pt.X > op1b.Pt.X ?
-              Direction.dRightToLeft : Direction.dLeftToRight);
+              Direction.RightToLeft : Direction.LeftToRight);
             Direction Dir2 = (op2.Pt.X > op2b.Pt.X ?
-              Direction.dRightToLeft : Direction.dLeftToRight);
+              Direction.RightToLeft : Direction.LeftToRight);
             if (Dir1 == Dir2) return false;
 
             //When DiscardLeft, we want Op1b to be on the Left of Op1, otherwise we
@@ -3397,7 +3397,7 @@ namespace TVGL.Boolean_Operations.Clipper
             //So, to facilitate this while inserting Op1b and Op2b ...
             //when DiscardLeft, make sure we're AT or RIGHT of Pt before adding Op1b,
             //otherwise make sure we're AT or LEFT of Pt. (Likewise with Op2b.)
-            if (Dir1 == Direction.dLeftToRight)
+            if (Dir1 == Direction.LeftToRight)
             {
                 while (op1.Next.Pt.X <= Pt.X &&
                   op1.Next.Pt.X >= op1.Pt.X && op1.Next.Pt.Y == Pt.Y)
@@ -3426,7 +3426,7 @@ namespace TVGL.Boolean_Operations.Clipper
                 }
             }
 
-            if (Dir2 == Direction.dLeftToRight)
+            if (Dir2 == Direction.LeftToRight)
             {
                 while (op2.Next.Pt.X <= Pt.X &&
                   op2.Next.Pt.X >= op2.Pt.X && op2.Next.Pt.Y == Pt.Y)
@@ -3455,7 +3455,7 @@ namespace TVGL.Boolean_Operations.Clipper
                 };
             };
 
-            if ((Dir1 == Direction.dLeftToRight) == DiscardLeft)
+            if ((Dir1 == Direction.LeftToRight) == DiscardLeft)
             {
                 op1.Prev = op2;
                 op2.Next = op1;
@@ -3986,25 +3986,25 @@ namespace TVGL.Boolean_Operations.Clipper
         //------------------------------------------------------------------------------
 
         internal static Paths SimplifyPolygon(Path poly,
-              PolyFillType fillType = PolyFillType.pftEvenOdd)
+              PolyFillType fillType = PolyFillType.EvenOdd)
         {
             Paths result = new Paths();
             Clipper c = new Clipper();
             c.StrictlySimple = true;
-            c.AddPath(poly, PolyType.ptSubject, true);
-            c.Execute(ClipType.ctUnion, result, fillType, fillType);
+            c.AddPath(poly, PolyType.Subject, true);
+            c.Execute(ClipType.Union, result, fillType, fillType);
             return result;
         }
         //------------------------------------------------------------------------------
 
         internal static Paths SimplifyPolygons(Paths polys,
-            PolyFillType fillType = PolyFillType.pftEvenOdd)
+            PolyFillType fillType = PolyFillType.EvenOdd)
         {
             Paths result = new Paths();
             Clipper c = new Clipper();
             c.StrictlySimple = true;
-            c.AddPaths(polys, PolyType.ptSubject, true);
-            c.Execute(ClipType.ctUnion, result, fillType, fillType);
+            c.AddPaths(polys, PolyType.Subject, true);
+            c.Execute(ClipType.Union, result, fillType, fillType);
             return result;
         }
         //------------------------------------------------------------------------------
@@ -4191,8 +4191,8 @@ namespace TVGL.Boolean_Operations.Clipper
         {
             Paths paths = Minkowski(pattern, path, true, pathIsClosed);
             Clipper c = new Clipper();
-            c.AddPaths(paths, PolyType.ptSubject, true);
-            c.Execute(ClipType.ctUnion, paths, PolyFillType.pftNonZero, PolyFillType.pftNonZero);
+            c.AddPaths(paths, PolyType.Subject, true);
+            c.Execute(ClipType.Union, paths, PolyFillType.NonZero, PolyFillType.NonZero);
             return paths;
         }
         //------------------------------------------------------------------------------
@@ -4213,15 +4213,15 @@ namespace TVGL.Boolean_Operations.Clipper
             for (int i = 0; i < paths.Count; ++i)
             {
                 Paths tmp = Minkowski(pattern, paths[i], true, pathIsClosed);
-                c.AddPaths(tmp, PolyType.ptSubject, true);
+                c.AddPaths(tmp, PolyType.Subject, true);
                 if (pathIsClosed)
                 {
                     Path path = TranslatePath(paths[i], pattern[0]);
-                    c.AddPath(path, PolyType.ptClip, true);
+                    c.AddPath(path, PolyType.Clip, true);
                 }
             }
-            c.Execute(ClipType.ctUnion, solution,
-              PolyFillType.pftNonZero, PolyFillType.pftNonZero);
+            c.Execute(ClipType.Union, solution,
+              PolyFillType.NonZero, PolyFillType.NonZero);
             return solution;
         }
         //------------------------------------------------------------------------------
@@ -4230,8 +4230,8 @@ namespace TVGL.Boolean_Operations.Clipper
         {
             Paths paths = Minkowski(poly1, poly2, false, true);
             Clipper c = new Clipper();
-            c.AddPaths(paths, PolyType.ptSubject, true);
-            c.Execute(ClipType.ctUnion, paths, PolyFillType.pftNonZero, PolyFillType.pftNonZero);
+            c.AddPaths(paths, PolyType.Subject, true);
+            c.Execute(ClipType.Union, paths, PolyFillType.NonZero, PolyFillType.NonZero);
             return paths;
         }
         //------------------------------------------------------------------------------
@@ -4339,7 +4339,7 @@ namespace TVGL.Boolean_Operations.Clipper
             newNode.MEndtype = endType;
 
             //strip duplicate points from path and also get index to the lowest point ...
-            if (endType == EndType.etClosedLine || endType == EndType.etClosedPolygon)
+            if (endType == EndType.ClosedLine || endType == EndType.ClosedPolygon)
                 while (highI > 0 && path[0] == path[highI]) highI--;
             newNode.MPolygon.Capacity = highI + 1;
             newNode.MPolygon.Add(path[0]);
@@ -4353,12 +4353,12 @@ namespace TVGL.Boolean_Operations.Clipper
                       (path[i].Y == newNode.MPolygon[k].Y &&
                       path[i].X < newNode.MPolygon[k].X)) k = j;
                 }
-            if (endType == EndType.etClosedPolygon && j < 2) return;
+            if (endType == EndType.ClosedPolygon && j < 2) return;
 
             m_polyNodes.AddChild(newNode);
 
             //if this path's lowest pt is lower than all the others then update m_lowest
-            if (endType != EndType.etClosedPolygon) return;
+            if (endType != EndType.ClosedPolygon) return;
             if (m_lowest.X < 0)
                 m_lowest = new IntPoint(m_polyNodes.ChildCount - 1, k);
             else
@@ -4389,8 +4389,8 @@ namespace TVGL.Boolean_Operations.Clipper
                 for (int i = 0; i < m_polyNodes.ChildCount; i++)
                 {
                     PolyNode node = m_polyNodes.Childs[i];
-                    if (node.MEndtype == EndType.etClosedPolygon ||
-                      (node.MEndtype == EndType.etClosedLine &&
+                    if (node.MEndtype == EndType.ClosedPolygon ||
+                      (node.MEndtype == EndType.ClosedLine &&
                       Clipper.Orientation(node.MPolygon)))
                         node.MPolygon.Reverse();
                 }
@@ -4400,7 +4400,7 @@ namespace TVGL.Boolean_Operations.Clipper
                 for (int i = 0; i < m_polyNodes.ChildCount; i++)
                 {
                     PolyNode node = m_polyNodes.Childs[i];
-                    if (node.MEndtype == EndType.etClosedLine &&
+                    if (node.MEndtype == EndType.ClosedLine &&
                       !Clipper.Orientation(node.MPolygon))
                         node.MPolygon.Reverse();
                 }
@@ -4434,7 +4434,7 @@ namespace TVGL.Boolean_Operations.Clipper
                 for (int i = 0; i < m_polyNodes.ChildCount; i++)
                 {
                     PolyNode node = m_polyNodes.Childs[i];
-                    if (node.MEndtype == EndType.etClosedPolygon)
+                    if (node.MEndtype == EndType.ClosedPolygon)
                         m_destPolys.Add(node.MPolygon);
                 }
                 return;
@@ -4467,14 +4467,14 @@ namespace TVGL.Boolean_Operations.Clipper
                 int len = m_srcPoly.Count;
 
                 if (len == 0 || (delta <= 0 && (len < 3 ||
-                  node.MEndtype != EndType.etClosedPolygon)))
+                  node.MEndtype != EndType.ClosedPolygon)))
                     continue;
 
                 m_destPoly = new Path();
 
                 if (len == 1)
                 {
-                    if (node.MJointype == JoinType.jtRound)
+                    if (node.MJointype == JoinType.Round)
                     {
                         double X = 1.0, Y = 0.0;
                         for (int j = 1; j <= steps; j++)
@@ -4509,20 +4509,20 @@ namespace TVGL.Boolean_Operations.Clipper
                 m_normals.Capacity = len;
                 for (int j = 0; j < len - 1; j++)
                     m_normals.Add(GetUnitNormal(m_srcPoly[j], m_srcPoly[j + 1]));
-                if (node.MEndtype == EndType.etClosedLine ||
-                  node.MEndtype == EndType.etClosedPolygon)
+                if (node.MEndtype == EndType.ClosedLine ||
+                  node.MEndtype == EndType.ClosedPolygon)
                     m_normals.Add(GetUnitNormal(m_srcPoly[len - 1], m_srcPoly[0]));
                 else
                     m_normals.Add(new DoublePoint(m_normals[len - 2]));
 
-                if (node.MEndtype == EndType.etClosedPolygon)
+                if (node.MEndtype == EndType.ClosedPolygon)
                 {
                     int k = len - 1;
                     for (int j = 0; j < len; j++)
                         OffsetPoint(j, ref k, node.MJointype);
                     m_destPolys.Add(m_destPoly);
                 }
-                else if (node.MEndtype == EndType.etClosedLine)
+                else if (node.MEndtype == EndType.ClosedLine)
                 {
                     int k = len - 1;
                     for (int j = 0; j < len; j++)
@@ -4546,7 +4546,7 @@ namespace TVGL.Boolean_Operations.Clipper
                         OffsetPoint(j, ref k, node.MJointype);
 
                     IntPoint pt1;
-                    if (node.MEndtype == EndType.etOpenButt)
+                    if (node.MEndtype == EndType.OpenButt)
                     {
                         int j = len - 1;
                         pt1 = new IntPoint((cInt)Round(m_srcPoly[j].X + m_normals[j].X *
@@ -4562,7 +4562,7 @@ namespace TVGL.Boolean_Operations.Clipper
                         k = len - 2;
                         m_sinA = 0;
                         m_normals[j] = new DoublePoint(-m_normals[j].X, -m_normals[j].Y);
-                        if (node.MEndtype == EndType.etOpenSquare)
+                        if (node.MEndtype == EndType.OpenSquare)
                             DoSquare(j, k);
                         else
                             DoRound(j, k);
@@ -4578,7 +4578,7 @@ namespace TVGL.Boolean_Operations.Clipper
                     for (int j = k - 1; j > 0; --j)
                         OffsetPoint(j, ref k, node.MJointype);
 
-                    if (node.MEndtype == EndType.etOpenButt)
+                    if (node.MEndtype == EndType.OpenButt)
                     {
                         pt1 = new IntPoint((cInt)Round(m_srcPoly[0].X - m_normals[0].X * delta),
                           (cInt)Round(m_srcPoly[0].Y - m_normals[0].Y * delta));
@@ -4591,7 +4591,7 @@ namespace TVGL.Boolean_Operations.Clipper
                     {
                         k = 1;
                         m_sinA = 0;
-                        if (node.MEndtype == EndType.etOpenSquare)
+                        if (node.MEndtype == EndType.OpenSquare)
                             DoSquare(0, 1);
                         else
                             DoRound(0, 1);
@@ -4609,11 +4609,11 @@ namespace TVGL.Boolean_Operations.Clipper
             DoOffset(delta);
             //now clean up 'corners' ...
             Clipper clpr = new Clipper();
-            clpr.AddPaths(m_destPolys, PolyType.ptSubject, true);
+            clpr.AddPaths(m_destPolys, PolyType.Subject, true);
             if (delta > 0)
             {
-                clpr.Execute(ClipType.ctUnion, solution,
-                  PolyFillType.pftPositive, PolyFillType.pftPositive);
+                clpr.Execute(ClipType.Union, solution,
+                  PolyFillType.Positive, PolyFillType.Positive);
             }
             else
             {
@@ -4625,9 +4625,9 @@ namespace TVGL.Boolean_Operations.Clipper
                 outer.Add(new IntPoint(r.right + 10, r.top - 10));
                 outer.Add(new IntPoint(r.left - 10, r.top - 10));
 
-                clpr.AddPath(outer, PolyType.ptSubject, true);
+                clpr.AddPath(outer, PolyType.Subject, true);
                 clpr.ReverseSolution = true;
-                clpr.Execute(ClipType.ctUnion, solution, PolyFillType.pftNegative, PolyFillType.pftNegative);
+                clpr.Execute(ClipType.Union, solution, PolyFillType.Negative, PolyFillType.Negative);
                 if (solution.Count > 0) solution.RemoveAt(0);
             }
         }
@@ -4641,11 +4641,11 @@ namespace TVGL.Boolean_Operations.Clipper
 
             //now clean up 'corners' ...
             Clipper clpr = new Clipper();
-            clpr.AddPaths(m_destPolys, PolyType.ptSubject, true);
+            clpr.AddPaths(m_destPolys, PolyType.Subject, true);
             if (delta > 0)
             {
-                clpr.Execute(ClipType.ctUnion, solution,
-                  PolyFillType.pftPositive, PolyFillType.pftPositive);
+                clpr.Execute(ClipType.Union, solution,
+                  PolyFillType.Positive, PolyFillType.Positive);
             }
             else
             {
@@ -4657,9 +4657,9 @@ namespace TVGL.Boolean_Operations.Clipper
                 outer.Add(new IntPoint(r.right + 10, r.top - 10));
                 outer.Add(new IntPoint(r.left - 10, r.top - 10));
 
-                clpr.AddPath(outer, PolyType.ptSubject, true);
+                clpr.AddPath(outer, PolyType.Subject, true);
                 clpr.ReverseSolution = true;
-                clpr.Execute(ClipType.ctUnion, solution, PolyFillType.pftNegative, PolyFillType.pftNegative);
+                clpr.Execute(ClipType.Union, solution, PolyFillType.Negative, PolyFillType.Negative);
                 //remove the outer PolyNode rectangle ...
                 if (solution.ChildCount == 1 && solution.Childs[0].ChildCount > 0)
                 {
@@ -4707,15 +4707,15 @@ namespace TVGL.Boolean_Operations.Clipper
             else
                 switch (jointype)
                 {
-                    case JoinType.jtMiter:
+                    case JoinType.Miter:
                         {
                             double r = 1 + (m_normals[j].X * m_normals[k].X +
                               m_normals[j].Y * m_normals[k].Y);
                             if (r >= m_miterLim) DoMiter(j, k, r); else DoSquare(j, k);
                             break;
                         }
-                    case JoinType.jtSquare: DoSquare(j, k); break;
-                    case JoinType.jtRound: DoRound(j, k); break;
+                    case JoinType.Square: DoSquare(j, k); break;
+                    case JoinType.Round: DoRound(j, k); break;
                 }
             k = j;
         }

--- a/TessellationAndVoxelizationGeometryLibrary/Properties/AssemblyInfo.cs
+++ b/TessellationAndVoxelizationGeometryLibrary/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -25,3 +26,6 @@
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+// Allow tests to access internal classes
+[assembly: InternalsVisibleTo("TVGLTest")]


### PR DESCRIPTION
This adds the clipper test suite, ported to C# as a set of NUnit tests. Originally, this work was done on top of the `polygon` branch in [`clipper-tests`](https://github.com/DesignEngrLab/TVGL/tree/clipper-tests), but after failing to get tests passing, I reverted to master so that I could ensure no bugs were introduced in the translation of tests. There were too many changes to keep track of in order to debug why tests weren't passing, mostly in one very large commit. This branch provides a starting point for making changes to the clipper code (i.e. replacing `IntPoint` with `Point`), without introducing new errors.

To run NUnit tests, install the NUnit extension (Tools > Extensions and Updates...) and then use the Test Explorer to run all tests or individual ones (Test > Windows > Test Explorer).
