### PR TITLE
update TryDequeue() to match Dequeue()

### DIFF
--- a/TessellationAndVoxelizationGeometryLibrary/Miscellaneous Functions/UpdatablePriorityQueue.cs
+++ b/TessellationAndVoxelizationGeometryLibrary/Miscellaneous Functions/UpdatablePriorityQueue.cs
@@ -329,6 +329,7 @@ namespace TVGL
             if (_size != 0)
             {
                 (element, priority) = _nodes[0];
+                _elementIndices.Remove(element);
                 RemoveRootNode();
                 return true;
             }


### PR DESCRIPTION
Hey @micampbell, I found a link to your UpdatablePriorityQueue at https://github.com/dotnet/runtime/issues/44871#issuecomment-1887717327 ... thanks for putting this together!.

I'm using it to great effect for my project, but I needed to fix a small bug before it would work for me. I added an additional update to the indices dictionary in the `TryDequeue()` to match what you had in `Dequeue()`.